### PR TITLE
Allowing the base path used by the build_bootstrap.php script to be configured

### DIFF
--- a/Resources/bin/build_bootstrap.php
+++ b/Resources/bin/build_bootstrap.php
@@ -10,8 +10,15 @@
  * file that was distributed with this source code.
  */
 
-if (!$baseDir = realpath(__DIR__.'/../../../../../../..')) {
-    exit('Looks like you don\'t have a standard layout.');
+$argv = $_SERVER['argv'];
+
+// allow the base path to be passed as the first argument, or default
+if (isset($argv[1])) {
+    $baseDir = $argv[1];
+} else {
+    if (!$baseDir = realpath(__DIR__.'/../../../../../../..')) {
+        exit('Looks like you don\'t have a standard layout.');
+    }
 }
 
 require_once $baseDir.'/vendor/symfony/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';


### PR DESCRIPTION
Hey guys!

This allows the base path used by the bootstrap build script to be configurable. This addresses a specific deployment problem where each deployment is a new clone of the project, but the vendor directory is symlinked to a "shared" directory for efficiency. In this case, since the vendor directory actually exists in a place outside of the project, the bootstrap file is built in the wrong location.

The related issue on capifony is #34. If this is accepted, I'll also make a PR to the standard distribution, so that the bin/vendors script explicitly passes the `$rootDir` path (https://github.com/symfony/symfony-standard/blob/master/bin/vendors#L13) when it calls the `build_bootstrap.php` file.

Thanks!
