### PR TITLE
add second argument: path where the bootstrap file will be generated.

### DIFF
--- a/Resources/bin/build_bootstrap.php
+++ b/Resources/bin/build_bootstrap.php
@@ -21,6 +21,13 @@ if (isset($argv[1])) {
     }
 }
 
+// allow the path where the bootstrap file will be generated to be passed as the second argument, or default
+if (isset($argv[2])) {
+    $appDir = $argv[2];
+} else {
+    $appDir = $baseDir . '/app';
+}
+
 require_once $baseDir.'/vendor/symfony/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';
 
 /*
@@ -39,7 +46,7 @@ $loader = new UniversalClassLoader();
 $loader->registerNamespaces(array('Symfony' => $baseDir.'/vendor/symfony/src'));
 $loader->register();
 
-$file = $baseDir.'/app/bootstrap.php.cache';
+$file = $appDir . '/bootstrap.php.cache';
 if (file_exists($file)) {
     unlink($file);
 }


### PR DESCRIPTION
I have separated the vendor dir for my projects. The main reason for doing this is to easily upgrade to another version of symfony without doing the upgrade for each project independently what consume too much time and may cause inconsistency (I may forgot to upgrade one of my projects).

So the script for generating bootstrap should reflect this situation.
Adding a second argument for the path where the bootstrap file wil be generated will fix this problem.
