### PR TITLE
Fix escaping

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -91,7 +91,7 @@ class ScriptHandler
     protected static function executeCommand($appDir, $cmd)
     {
         $phpFinder = new PhpExecutableFinder;
-        $php = escapeshellcmd($phpFinder->find());
+        $php = escapeshellarg($phpFinder->find());
         $console = escapeshellarg($appDir.'/console');
 
         $process = new Process($php.' '.$console.' '.$cmd);


### PR DESCRIPTION
Currently the symfony-standard stuff breaks if you have a space in your php path (which some windows users do when installing to Program Files), this is part 1 of the fix, part 2 needs you to make sure the https://github.com/symfony/Process split is up to date so I can update it in Composer (it needs the windows compatibility enhancement thing that got merged recently).
