### PR TITLE
Generate random secret if there is no parameter named secret

### DIFF
--- a/Configurator/Step/SecretStep.php
+++ b/Configurator/Step/SecretStep.php
@@ -28,11 +28,21 @@ class SecretStep implements StepInterface
 
     public function __construct(array $parameters)
     {
-        $this->secret = $parameters['secret'];
+        if (array_key_exists('secret', $parameters)){
+            $this->secret = $parameters['secret'];
 
-        if ('ThisTokenIsNotSoSecretChangeIt' == $this->secret) {
-            $this->secret = hash('sha1', uniqid(mt_rand()));
+            if ('ThisTokenIsNotSoSecretChangeIt' == $this->secret) {
+                $this->secret = $this->generateRandomSecret();
+            }
+        } else {
+            $this->secret = $this->generateRandomSecret();
         }
+
+    }
+
+    private function generateRandomSecret()
+    {
+        return hash('sha1', uniqid(mt_rand()));
     }
 
     /**


### PR DESCRIPTION
For some weird reason after updating from symfony 2.0.1 to symfony-standard master branch I kept having undefined index secret errors, event though I had a parameter named secret in my parameters section of the config file (not in the .ini file)

This PR solves this issue by generating a random secret if I do not specify one
