### PR TITLE
env variable did have no effect at all

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -111,7 +111,7 @@ class ScriptHandler
             'symfony-assets-install' => 'hard'
         ), $event->getComposer()->getPackage()->getExtra());
 
-        $options['symfony-assets-install'] = $options['symfony-assets-install'] ?: getenv('SYMFONY_ASSETS_INSTALL');
+        $options['symfony-assets-install'] = getenv('SYMFONY_ASSETS_INSTALL') ?: $options['symfony-assets-install'];
 
         return $options;
     }


### PR DESCRIPTION
when $options['symfony-assets-install'] is set (always?), the env variable's value did not have any effect, order should be reversed
