### PR TITLE
fix asset install relative option

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -53,8 +53,11 @@ class ScriptHandler
         $webDir = $options['symfony-web-dir'];
 
         $symlink = '';
-        if (in_array($options['symfony-assets-install'], array('symlink', 'relative'))) {
-            $symlink = '--'.$options['symfony-assets-install'].' ';
+        if ($options['symfony-assets-install'] == 'symlink') {
+            $symlink = '--symlink ';
+        }
+        elseif ($options['symfony-assets-install'] == 'relative') {
+            $symlink = '--symlink --relative ';
         }
 
         if (!is_dir($webDir)) {


### PR DESCRIPTION
the assets:install --symlink option was missing when using composer extra option relative
