### PR TITLE
Bug fix for spaces for the composer script 

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -109,10 +109,10 @@ class ScriptHandler
     {
         $phpFinder = new PhpExecutableFinder;
         $php = escapeshellarg($phpFinder->find());
-        $cmd = __DIR__.'/../Resources/bin/build_bootstrap.php';
+        $cmd = escapeshellarg(__DIR__.'/../Resources/bin/build_bootstrap.php');
         $appDir = escapeshellarg($appDir);
 
-        $process = new Process($php.' "'.$cmd.'" '.$appDir);
+        $process = new Process($php.' '.$cmd.' '.$appDir);
         $process->run(function ($type, $buffer) { echo $buffer; });
     }
 


### PR DESCRIPTION
When generating the bootstrap with `Composer`, the script crashes with paths with spaces.
