### PR TITLE
wrong path to app directory in build_bootstrap.php

### DIFF
--- a/Resources/bin/build_bootstrap.php
+++ b/Resources/bin/build_bootstrap.php
@@ -16,7 +16,7 @@ $argv = $_SERVER['argv'];
 if (isset($argv[1])) {
     $appDir = $argv[1];
 } else {
-    if (!$appDir = realpath(__DIR__.'/../../../../../../../../app')) {
+    if (!$appDir = realpath(__DIR__.'/../../../../../../../app')) {
         exit('Looks like you don\'t have a standard layout.');
     }
 }


### PR DESCRIPTION
Hi all

there is a wrong path to the app's directory in Resources/bin/build_bootstrap.php when you don't add an argument.
