### PR TITLE
Corrected suhosin detection

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -477,13 +477,7 @@ class SymfonyRequirements extends RequirementCollection
 
         $this->addPhpIniRequirement('detect_unicode', false);
 
-        ob_start();
-        phpinfo();
-        $phpinfo = ob_get_contents();
-        ob_end_clean();
-
-        // the phpinfo check is necessary when Suhosin is compiled into PHP
-        if (extension_loaded('suhosin') || false !== strpos($phpinfo, 'Suhosin')) {
+        if (extension_loaded('suhosin')) {
             $this->addPhpIniRequirement(
                 'suhosin.executor.include.whitelist',
                 create_function('$cfgValue', 'return false !== stripos($cfgValue, "phar");'),


### PR DESCRIPTION
The phpinfo test is not accurate.
See http://www.hardened-php.net/suhosin/index.html

> Suhosin comes in two independent parts, that can be used separately or in combination. The first part is a small patch against the PHP core, that implements a few low-level protections against bufferoverflows or format string vulnerabilities and the second part is a powerful PHP extension that implements all the other protections.

and

> When you only use the Suhosin-Patch only the logging features are supported. When you only use the Suhosin-Extension you cannot use the predefined constants for configuration.

Searching for Suhosin in phpinfo leads to false positives when the core patch is applied and the extension is not loaded / compiled into php.
The suhosin.executor.include.whitelist option is only used by the extension and not by the core patch. 
extension_loaded also works with compiled in extensions.
