### PR TITLE
ScripHandler method to dump assets on composer install/update

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -123,6 +123,20 @@ namespace { return \$loader; }
             ", substr(file_get_contents($file), 5)));
     }
 
+    public static function dumpAssetic($event)
+    {
+        $options = self::getOptions($event);
+        $appDir = $options['symfony-app-dir'];
+
+        if (!is_dir($appDir)) {
+            echo 'The symfony-app-dir ('.$appDir.') specified in composer.json was not found in '.getcwd().', can not dump assets.'.PHP_EOL;
+
+            return;
+        }
+
+        static::executeCommand($event, $appDir, 'assetic:dump', $options['process-timeout']);
+    }
+
     protected static function executeCommand($event, $appDir, $cmd, $timeout = 300)
     {
         $php = escapeshellarg(self::getPhp());


### PR DESCRIPTION
such method was originaly added by @arjenjb but disappeared after a rebase

Simple dumpAssetic() method to add such a command on composer install/update.
I just copy/paste and customize to call assetic:dump command.

Maybe I could refactor static methods for common assertions (like checking if $appDir exists) rather than duplicate code in each method. Is there any interest ?
