### PR TITLE
Adding app-specific requirements to app/check.php

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -81,6 +81,7 @@ class ScriptHandler
             return;
         }
 
+        copy(__DIR__.'/../Resources/skeleton/app/AppRequirements.php.dist', $appDir.'/AppRequirements.php.dist');
         copy(__DIR__.'/../Resources/skeleton/app/SymfonyRequirements.php', $appDir.'/SymfonyRequirements.php');
         copy(__DIR__.'/../Resources/skeleton/app/check.php', $appDir.'/check.php');
 

--- a/Resources/skeleton/app/AppRequirements.php.dist
+++ b/Resources/skeleton/app/AppRequirements.php.dist
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*
+ * Users of PHP 5.2 should be able to run the requirements checks.
+ * This is why the file and all classes must be compatible with PHP 5.2+
+ * (e.g. not using namespaces and closures).
+ */
+
+/**
+ * To add your own requirements to app/check.php, copy this file to
+ * app/AppRequirements.php and add requirements to the constructor. See below 
+ * for examples.
+ *
+ * Do not edit the contents of this file directly. It will be overriden by
+ * Composer on the next install/update.
+ */
+
+require_once dirname(__FILE__).'/SymfonyRequirements.php';
+
+class AppRequirements extends RequirementCollection
+{
+    public function __construct()
+    {
+        // $this->addRequirement(); 
+        // $this->addRecommendation();
+    }
+}

--- a/Resources/skeleton/app/check.php
+++ b/Resources/skeleton/app/check.php
@@ -4,6 +4,13 @@ require_once dirname(__FILE__).'/SymfonyRequirements.php';
 
 $symfonyRequirements = new SymfonyRequirements();
 
+if (file_exists(dirname(__FILE__).'/AppRequirements.php')) {
+    require_once dirname(__FILE__).'/AppRequirements.php';
+    $appRequirements = new AppRequirements();
+} else {
+    $appRequirements = null;
+}
+
 $iniPath = $symfonyRequirements->getPhpIniConfigPath();
 
 echo "********************************\n";
@@ -29,20 +36,32 @@ foreach ($symfonyRequirements->getRequirements() as $req) {
     echo_requirement($req);
 }
 
+if ($appRequirements) {
+    foreach ($appRequirements->getRequirements() as $req) {
+        echo_requirement($req, 'App requirement: ');
+    }
+}
+
 echo_title('Optional recommendations');
 
 foreach ($symfonyRequirements->getRecommendations() as $req) {
     echo_requirement($req);
 }
 
+if ($appRequirements) {
+    foreach ($appRequirements->getRecommendations() as $req) {
+        echo_requirement($req, 'App recommendation: ');
+    }
+}
+
 /**
  * Prints a Requirement instance
  */
-function echo_requirement(Requirement $requirement)
+function echo_requirement(Requirement $requirement, $prefix = '')
 {
     $result = $requirement->isFulfilled() ? 'OK' : ($requirement->isOptional() ? 'WARNING' : 'ERROR');
     echo ' ' . str_pad($result, 9);
-    echo $requirement->getTestMessage() . "\n";
+    echo $prefix . $requirement->getTestMessage() . "\n";
 
     if (!$requirement->isFulfilled()) {
         echo sprintf("          %s\n\n", $requirement->getHelpText());


### PR DESCRIPTION
Hello,

This pull request defines an `AppRequirements.php.dist` file that developers can optionally rename and edit in their own projects to specify app-specific requirements.

For example:
If my app requires the memcache PHP extension, I can rename `app/AppRequirements.php.dist` to `app/AppRequirements.php`, and specify my requirements in the same way that Symfony can in `SymfonyRequirements.php`

```php
class AppRequirements extends RequirementCollection
{
    public function __construct()
    {
        $this->addRequirement(
            class_exists('Memcache'),
            'memcache extension should be installed',
            'You must install the <strong>memcache</strong> extension (used for caching users)'
        );

        $this->addRecommendation(
            // My recommendation.
        );
    }
}
```

These requirements and recommendations will be displayed along with the usual requirements when the user runs `app/check.php`. However, they will be prefixed with "App requirement: " and "App recommendation: " so that it is obvious what is a requirement/recommendation of Symfony versus the app.

If there is no `app/AppRequirements.php` file, the check is ignore, and things work just as they otherwise do.