### PR TITLE
Composer ScriptHandler to run assetic:dump from a script hook

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -80,10 +80,16 @@ class ScriptHandler
         if ($options['assetic-dump-force']) {
             $arguments[] = '--force';
         }
+        
         if ($options['assetic-dump-asset-root'] !== null) {
             $arguments = escapeshellarg($options['assetic-dump-asset-root']);
         }
 
+        if (!is_dir($webDir)) {
+            echo 'The symfony-app-dir ('.$webDir.') specified in composer.json was not found in '.getcwd().', can not install assets.'.PHP_EOL;
+            return;
+        }
+        
         static::executeCommand($event, $appDir, 'assetic:dump' . implode(' ', $arguments));
     }
 


### PR DESCRIPTION
Introduces following configuration options:

``` php
array(
    'assetic-dump-asset-root' => null,
    'assetic-dump-force' => false
);
```

The following ScriptHandler can be added:

``` json
{
    "post-install-cmd": [
        "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::dumpAssetic"
    ]
}
```

This is a copy of #34, which apparently was abandommed by its original author. The code was believed to be lost due to bad rebase, but I found [this gist](https://gist.github.com/2725096).
