### PR TITLE
Add phpIniRecommendation for xdebug.max_nesting_level limit

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -503,6 +503,14 @@ class SymfonyRequirements extends RequirementCollection
             $this->addPhpIniRequirement(
                 'xdebug.scream', false, true
             );
+            
+            $this->addPhpIniRecommendation(
+                'xdebug.max_nesting_level', 
+                create_function('$cfgValue', 'return $cfgValue > 100;'),
+                true, 
+                'xdebug.max_nesting_level should be above 100 in php.ini', 
+                'Set "<strong>xdebug.max_nesting_level</strong>" to e.g. "<strong>250</strong>" in php.ini<a href="#phpini">*</a> to stop Xdebug\'s infinite recursion protection erroneously throwing a fatal error in your project.'
+            );
         }
 
         $pcreVersion = defined('PCRE_VERSION') ? (float) PCRE_VERSION : null;


### PR DESCRIPTION
The Xdebug extension includes infinite recursion protection, which throws a PHP fatal error if function nesting exceeds a configurable limit.

Unfortunately the default limit is so low that it is often exceeded in normal execution by symfony projects (especially in the dev environment). This triggers a panicked and futile search for a coding problem where none exists.

This commit adds a recommendation to increase the max_nesting_level limit above the default if Xdebug is loaded.
