### PR TITLE
Copy Config only if doesn't exist

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -117,7 +117,7 @@ class ScriptHandler
 
         $webDir = $options['symfony-web-dir'];
 
-        if (is_file($webDir.'/config.php')) {
+        if (!file_exists($webDir.'/config.php')) {
             copy(__DIR__.'/../Resources/skeleton/web/config.php', $webDir.'/config.php');
         }
     }


### PR DESCRIPTION
Fixed an error where current functionality was copying file
only if the file was already in the expected directory location.
Changed the composer script handler to copy the config.php skeleton
file over only if the file does not already exist.
