### PR TITLE
Just output a warning but don't prevent usage through non-cli SAPIs

### DIFF
--- a/Resources/bin/build_bootstrap.php
+++ b/Resources/bin/build_bootstrap.php
@@ -11,8 +11,7 @@
  */
 
 if (PHP_SAPI !== 'cli') {
-    echo __FILE__.' should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
-    exit(1);
+    echo 'Warning: '.__FILE__.' should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
 }
 
 $argv = $_SERVER['argv'];


### PR DESCRIPTION
Composer has also turned this into a warning in composer/composer@c1ff6ea62bb2c196e777bcd51ac6da287ad44b5a
