### PR TITLE
Detect Zend OPcache and WinCache as PHP Accelerators

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -630,11 +630,15 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         $accelerator =
-            (function_exists('apc_store') && ini_get('apc.enabled'))
+            (extension_loaded('eaccelerator') && ini_get('eaccelerator.enable'))
             ||
-            function_exists('eaccelerator_put') && ini_get('eaccelerator.enable')
+            (extension_loaded('apc') && ini_get('apc.enabled'))
             ||
-            function_exists('xcache_set')
+            (extension_loaded('Zend OPcache') && ini_get('opcache.enable'))
+            ||
+            (extension_loaded('xcache') && ini_get('xcache.cacher'))
+            ||
+            (extension_loaded('wincache') && ini_get('wincache.ocenabled'))
         ;
 
         $this->addRecommendation(


### PR DESCRIPTION
Now opcache, wincache shows "OK" as PHP Accelerators (when present and enabled)
Updated check method, cloning the funcionality used in HttpKernel (ConfigDataCollector.php)

This PR replaces #86 (done in branch 2.1), closed because is not maintained anymore.
