### PR TITLE
Missing rename parameter

### DIFF
--- a/Resources/config/webconfigurator.xml
+++ b/Resources/config/webconfigurator.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="sensio_distribution.webconfigurator" class="%sensio.distribution.webconfigurator.class%">
+        <service id="sensio_distribution.webconfigurator" class="%sensio_distribution.webconfigurator.class%">
             <argument>%kernel.root_dir%</argument>
         </service>
 


### PR DESCRIPTION
Hi, 
After update, i've error message :
[Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]  
  The service "sensio_distribution.webconfigurator" has a dependency on a non-existent parameter "sensio.distribution.webconfigurator.class". Did you mean this: "sensio_distribution.webconfigurator.class"?

I've fix itt and test it, all is good!

Regards
