### PR TITLE
Set command environment based on SYMFONY_ENV

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -183,6 +183,10 @@ namespace { return \$loader; }
         if ($event->getIO()->isDecorated()) {
             $console .= ' --ansi';
         }
+        
+        if ($environment = getenv('SYMFONY_ENV')) {
+            $cmd .= ' --env='.$environment;
+        }
 
         $process = new Process($php.' '.$console.' '.$cmd, null, null, null, $timeout);
         $process->run(function ($type, $buffer) { echo $buffer; });


### PR DESCRIPTION
For example : `SYMFONY_ENV=prod composer run-script post-install-cmd`

I saw some discussions about this feature, hope that's a good way to achieve this as it would be very usefull !
