### PR TITLE
Check for composer autoloader

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -158,7 +158,7 @@ class ScriptHandler
         // which won't be included into the cache then.
         // we know that composer autoloader is first (see bin/build_bootstrap.php)
         $autoloaders = spl_autoload_functions();
-        if ($autoloaders[0][0]->findFile('Symfony\\Bundle\\FrameworkBundle\\HttpKernel')) {
+        if (is_array($autoloaders[0]) && method_exists( $autoloaders[0][0], 'findFile') && $autoloaders[0][0]->findFile('Symfony\\Bundle\\FrameworkBundle\\HttpKernel')) {
             $classes[] = 'Symfony\\Bundle\\FrameworkBundle\\HttpKernel';
         } else {
             $classes[] = 'Symfony\\Component\\HttpKernel\\DependencyInjection\\ContainerAwareHttpKernel';


### PR DESCRIPTION
Is not always true that first autoloader is a composer autoloader.
using `spl_autoload_register` with `$prepend = true` will produce errors as:

_Fatal error: Cannot use object of type Closure as array in vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Composer/ScriptHandler.php on line 161_
or similar
