### PR TITLE
Updated PDO driver requirement to use boolean

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -690,7 +690,7 @@ class SymfonyRequirements extends RequirementCollection
         if (class_exists('PDO')) {
             $drivers = PDO::getAvailableDrivers();
             $this->addRecommendation(
-                count($drivers),
+                count($drivers) > 0,
                 sprintf('PDO should have some drivers installed (currently available: %s)', count($drivers) ? implode(', ', $drivers) : 'none'),
                 'Install <strong>PDO drivers</strong> (mandatory for Doctrine).'
             );


### PR DESCRIPTION
Scrutinizer picks up on this as a minor bug. I.e. count($drivers) returns an integer rather than a boolean.
