### PR TITLE
Refactored Configurator to ease addition of new steps

### DIFF
--- a/Configurator/Configurator.php
+++ b/Configurator/Configurator.php
@@ -18,11 +18,13 @@ use Symfony\Component\Yaml\Yaml;
  * Configurator.
  *
  * @author Marc Weistroff <marc.weistroff@gmail.com>
+ * @author Jérôme Vieilledent <lolautruche@gmail.com>
  */
 class Configurator
 {
     protected $filename;
     protected $steps;
+    protected $sortedSteps;
     protected $parameters;
 
     public function __construct($kernelDir)
@@ -48,10 +50,16 @@ class Configurator
 
     /**
      * @param StepInterface $step
+     * @param int $priority
      */
-    public function addStep(StepInterface $step)
+    public function addStep(StepInterface $step, $priority = 0)
     {
-        $this->steps[] = $step;
+        if (!isset($this->steps[$priority])) {
+            $this->steps[$priority] = array();
+        }
+
+        $this->steps[$priority][] = $step;
+        $this->sortedSteps = null;
     }
 
     /**
@@ -61,17 +69,43 @@ class Configurator
      */
     public function getStep($index)
     {
-        if (isset($this->steps[$index])) {
-            return $this->steps[$index];
+        $steps = $this->getSteps();
+        if (isset($steps[$index])) {
+            return $steps[$index];
         }
     }
 
     /**
-     * @return array
+     * @return StepInterface[]
      */
     public function getSteps()
     {
-        return $this->steps;
+        if ($this->sortedSteps === null) {
+            $this->sortedSteps = $this->getSortedSteps();
+            foreach ($this->sortedSteps as $step) {
+                $step->setParameters($this->parameters);
+            }
+        }
+
+        return $this->sortedSteps;
+    }
+
+    /**
+     * Sort routers by priority.
+     * The highest priority number is the highest priority (reverse sorting)
+     *
+     * @return StepInterface[]
+     */
+    private function getSortedSteps()
+    {
+        $sortedSteps = array();
+        krsort($this->steps);
+
+        foreach ($this->steps as $steps) {
+            $sortedSteps = array_merge($sortedSteps, $steps);
+        }
+
+        return $sortedSteps;
     }
 
     /**
@@ -87,7 +121,7 @@ class Configurator
      */
     public function getStepCount()
     {
-        return count($this->steps);
+        return count($this->getSteps());
     }
 
     /**
@@ -104,7 +138,7 @@ class Configurator
     public function getRequirements()
     {
         $majors = array();
-        foreach ($this->steps as $step) {
+        foreach ($this->getSteps() as $step) {
             foreach ($step->checkRequirements() as $major) {
                 $majors[] = $major;
             }
@@ -119,7 +153,7 @@ class Configurator
     public function getOptionalSettings()
     {
         $minors = array();
-        foreach ($this->steps as $step) {
+        foreach ($this->getSteps() as $step) {
             foreach ($step->checkOptionalSettings() as $minor) {
                 $minors[] = $minor;
             }

--- a/Configurator/Step/DoctrineStep.php
+++ b/Configurator/Step/DoctrineStep.php
@@ -50,7 +50,7 @@ class DoctrineStep implements StepInterface
 
     public $path;
 
-    public function __construct(array $parameters)
+    public function setParameters(array $parameters)
     {
         foreach ($parameters as $key => $value) {
             if (0 === strpos($key, 'database_')) {

--- a/Configurator/Step/SecretStep.php
+++ b/Configurator/Step/SecretStep.php
@@ -26,7 +26,7 @@ class SecretStep implements StepInterface
      */
     public $secret;
 
-    public function __construct(array $parameters)
+    public function setParameters(array $parameters)
     {
         if (array_key_exists('secret', $parameters)) {
             $this->secret = $parameters['secret'];
@@ -37,7 +37,6 @@ class SecretStep implements StepInterface
         } else {
             $this->secret = $this->generateRandomSecret();
         }
-
     }
 
     private function generateRandomSecret()

--- a/Configurator/Step/StepInterface.php
+++ b/Configurator/Step/StepInterface.php
@@ -11,8 +11,6 @@
 
 namespace Sensio\Bundle\DistributionBundle\Configurator\Step;
 
-use Symfony\Component\Form\Type\FormTypeInterface;
-
 /**
  * StepInterface.
  *
@@ -21,16 +19,16 @@ use Symfony\Component\Form\Type\FormTypeInterface;
 interface StepInterface
 {
     /**
-     * __construct
+     * Injects existing parameters (from parameters.yml).
      *
      * @param array $parameters
      */
-    public function __construct(array $parameters);
+    public function setParameters(array $parameters);
 
     /**
      * Returns the form used for configuration.
      *
-     * @return FormTypeInterface
+     * @return \Symfony\Component\Form\FormTypeInterface
      */
     public function getFormType();
 
@@ -58,7 +56,8 @@ interface StepInterface
     /**
      * Updates form data parameters.
      *
-     * @param  array $parameters
+     * @param StepInterface $data
+     *
      * @return array
      */
     public function update(StepInterface $data);

--- a/DependencyInjection/Compiler/StepsPass.php
+++ b/DependencyInjection/Compiler/StepsPass.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\DistributionBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass to add steps to the web configurator.
+ *
+ * @author Jérôme Vieilledent <lolautruche@gmail.com>
+ */
+class StepsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('sensio_distribution.webconfigurator')) {
+            return;
+        }
+
+        $configuratorDef = $container->findDefinition('sensio_distribution.webconfigurator');
+        foreach ($container->findTaggedServiceIds('webconfigurator.step') as $id => $tags) {
+            $priority = isset($tags[0]['priority']) ? $tags[0]['priority'] : 0;
+            $configuratorDef->addMethodCall('addStep', array(new Reference($id), $priority));
+        }
+    }
+}

--- a/Resources/config/webconfigurator.xml
+++ b/Resources/config/webconfigurator.xml
@@ -6,11 +6,21 @@
 
     <parameters>
         <parameter key="sensio_distribution.webconfigurator.class">Sensio\Bundle\DistributionBundle\Configurator\Configurator</parameter>
+        <parameter key="sensio_distribution.webconfigurator.doctrine_step.class">Sensio\Bundle\DistributionBundle\Configurator\Step\DoctrineStep</parameter>
+        <parameter key="sensio_distribution.webconfigurator.secret_step.class">Sensio\Bundle\DistributionBundle\Configurator\Step\SecretStep</parameter>
     </parameters>
 
     <services>
         <service id="sensio_distribution.webconfigurator" class="%sensio_distribution.webconfigurator.class%">
             <argument>%kernel.root_dir%</argument>
+        </service>
+
+        <service id="sensio_distribution.webconfigurator.doctrine_step" class="%sensio_distribution.webconfigurator.doctrine_step.class%" public="false">
+            <tag name="webconfigurator.step" priority="10" />
+        </service>
+
+        <service id="sensio_distribution.webconfigurator.secret_step" class="%sensio_distribution.webconfigurator.secret_step.class%" public="false">
+            <tag name="webconfigurator.step" />
         </service>
 
         <!-- deprecated, kept for BC -->

--- a/SensioDistributionBundle.php
+++ b/SensioDistributionBundle.php
@@ -11,22 +11,21 @@
 
 namespace Sensio\Bundle\DistributionBundle;
 
+use Sensio\Bundle\DistributionBundle\DependencyInjection\Compiler\StepsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Sensio\Bundle\DistributionBundle\Configurator\Step\DoctrineStep;
-use Sensio\Bundle\DistributionBundle\Configurator\Step\SecretStep;
 
 /**
  * SensioDistributionBundle.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Marc Weistroff <marc.weistroff@sensio.com>
+ * @author Jérôme Vieilledent <lolautruche@gmail.com>
  */
 class SensioDistributionBundle extends Bundle
 {
-    public function boot()
+    public function build(ContainerBuilder $container)
     {
-        $configurator = $this->container->get('sensio_distribution.webconfigurator');
-        $configurator->addStep(new DoctrineStep($configurator->getParameters()));
-        $configurator->addStep(new SecretStep($configurator->getParameters()));
+        $container->addCompilerPass(new StepsPass());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | N/A |
| Fixed tickets | #90 |
| License | MIT |

This PR gives the possibility to easily add new steps to the web configurator, with priority.

``` yaml
services:
    my_custom_step:
        class: %my_custom_step.class%
        tags:
            - { name: webconfigurator.step, priority: 20 }
```

It would be nice to have it in 2.3 branch :smiley: 
