### PR TITLE
bugfix: missing console file with symfony3 directory structure

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -433,7 +433,7 @@ namespace { return \$loader; }
 !var/logs/.gitkeep
 /build/
 /vendor/
-/bin/
+/bin/*
 !bin/console
 !bin/symfony_requirements
 /composer.phar


### PR DESCRIPTION
When creating a new project with Symfony3 directory structure, <code>bin/console</code> is not found in commit list (get ignored). Therefore when the commit is cloned, <code>bin/console</code> file is missing.
nb: my os is windows
