### PR TITLE
Use /bin/* in .gitignore for new directory structure

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -433,7 +433,7 @@ namespace { return \$loader; }
 !var/logs/.gitkeep
 /build/
 /vendor/
-/bin/
+/bin/*
 !bin/console
 !bin/symfony_requirements
 /composer.phar


### PR DESCRIPTION
If using "/bin/" in .gitignore the two exclusions have no effect:
...
!bin/console
!bin/symfony_requirements
...

Tested with git 2.0
