### PR TITLE
Fix phpunit.xml.dist in new directory structure

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -438,8 +438,19 @@ namespace { return \$loader; }
 !bin/symfony_requirements
 /composer.phar
 EOF;
-
-        $phpunit = str_replace(array('<directory>../src/', '"bootstrap.php.cache"'), array('<directory>src/', '"'.$varDir.'/bootstrap.php.cache"'), file_get_contents($rootDir.'/phpunit.xml.dist'));
+        $phpunitKernelBefore = <<<EOF
+    <!--
+    <php>
+        <server name="KERNEL_DIR" value="/path/to/your/app/" />
+    </php>
+    -->
+EOF;
+        $phpunitKernelAfter = <<<EOF
+    <php>
+        <server name="KERNEL_DIR" value="$appDir/" />
+    </php>
+EOF;
+        $phpunit = str_replace(array('<directory>../src/', '"bootstrap.php.cache"', $phpunitKernelBefore), array('<directory>src/', '"'.$varDir.'/bootstrap.php.cache"', $phpunitKernelAfter),  file_get_contents($rootDir.'/phpunit.xml.dist'));
         $composer = str_replace("\"symfony-app-dir\": \"app\",", "\"symfony-app-dir\": \"app\",\n        \"symfony-bin-dir\": \"bin\",\n        \"symfony-var-dir\": \"var\",", file_get_contents($rootDir.'/composer.json'));
         $travis = str_replace("\nscript: phpunit -c app", '', file_get_contents($rootDir.'/.travis.yml'));
 


### PR DESCRIPTION
- [X] The bootstrap setting of phpunit wasn't updated in the new directory structure.
- [X] We need to add the `<php><server name="KERNEL_DIR" value="app/" /></php>` part because the [KernelTest::getKernelClass()](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php#L101) search by default the Kernel in the same directory than phpunit.xml.dist, which is not the case anymore

Any opinion on this @fabpot or @romainneutron?
