### PR TITLE
Use prod environment when using --no-dev

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -11,11 +11,11 @@
 
 namespace Sensio\Bundle\DistributionBundle\Composer;
 
+use Composer\Script\CommandEvent;
 use Symfony\Component\ClassLoader\ClassCollectionLoader;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Process\Process;
 use Symfony\Component\Process\PhpExecutableFinder;
-use Composer\Script\CommandEvent;
+use Symfony\Component\Process\Process;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -377,6 +377,9 @@ namespace { return \$loader; }
         $console = escapeshellarg($consoleDir.'/console');
         if ($event->getIO()->isDecorated()) {
             $console .= ' --ansi';
+        }
+        if (false === $event->isDevMode()) {
+            $console .= ' --env=prod';
         }
 
         $process = new Process($php.' '.$console.' '.$cmd, null, null, null, $timeout);


### PR DESCRIPTION
Hi everyone.

I propose this little fix to fix this issue : https://github.com/sensiolabs/SensioDistributionBundle/issues/139

I've got the same problem. I'm using a bundle only in dev environment, but when I execute `composer install --no-dev` but the scriptHandler launch a cache:clear in dev environment. It's a problem because the cache:clear is launched in dev environment... but one of the bundle registered in the AppKernel is not installed by composer due to the `--no-dev`. So I've got a "class not found" during the `cache:clear`.
