### PR TITLE
Removed undefined constant ScriptHandler::NEW_STRUCTURE_NOTIFIER

### DIFF
--- a/Resources/bin/build_bootstrap.php
+++ b/Resources/bin/build_bootstrap.php
@@ -46,7 +46,7 @@ if (null === $autoloadDir) {
 }
 if (null === $bootstrapDir) {
     $bootstrapDir = $autoloadDir;
-    if (file_exists($rootDir.'/var/'.ScriptHandler::NEW_STRUCTURE_NOTIFIER)) {
+    if ($useNewDirectoryStructure) {
         $bootstrapDir = getRealpath($rootDir.'/var');
     }
 }


### PR DESCRIPTION
Fixed #138

The constant `ScriptHandler::NEW_STRUCTURE_NOTIFIER` was used on [`Resources/bin/build_bootstrap.php#L49`](https://github.com/sensiolabs/SensioDistributionBundle/blob/master/Resources/bin/build_bootstrap.php#L49). This constant was temporarily created - then removed - during the development of the PR #118.
