### PR TITLE
Making the 3.0 directory structure question not asked unless you have a constant

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -43,7 +43,7 @@ class ScriptHandler
     {
         $options = self::getOptions($event);
 
-        if (getenv('SENSIOLABS_DISABLE_NEW_DIRECTORY_STRUCTURE') || !$event->getIO()->askConfirmation('Would you like to use Symfony 3 directory structure? [y/N] ', false)) {
+        if (!getenv('SENSIOLABS_ENABLE_NEW_DIRECTORY_STRUCTURE') || !$event->getIO()->askConfirmation('Would you like to use Symfony 3 directory structure? [y/N] ', false)) {
             return;
         }
 


### PR DESCRIPTION
Hi guys!

This follows symfony/symfony-standard#674

Basically, I'm seeing beginners choose "Y" for the Symfony 3 directory structure and then being very confused when their project doesn't look right. I realize this may be a bit controversial, but I just don't see the advantage yet of allowing people to install the "Symfony 3" directory structure until we're actually ready to release Symfony 3 and can update all the documentation accordingly. I've still made it possible to use the 3.0 dir structure, but only for someone who knows what they're doing (i.e. will set a constant).

I know I wasn't active in the conversation when this decision was made - so apologies for coming late - I just missed it before :).

Thanks!
