### PR TITLE
Fix composer update via HHVM

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -395,7 +395,7 @@ namespace { return \$loader; }
     protected static function executeCommand(CommandEvent $event, $consoleDir, $cmd, $timeout = 300)
     {
         $php = escapeshellarg(self::getPhp(false));
-        $phpArgs = implode(' ', array_map("escapeshellarg", self::getPhpArguments()));
+        $phpArgs = implode(' ', array_map('escapeshellarg', self::getPhpArguments()));
         $console = escapeshellarg($consoleDir.'/console');
         if ($event->getIO()->isDecorated()) {
             $console .= ' --ansi';
@@ -411,7 +411,7 @@ namespace { return \$loader; }
     protected static function executeBuildBootstrap(CommandEvent $event, $bootstrapDir, $autoloadDir, $timeout = 300)
     {
         $php = escapeshellarg(self::getPhp(false));
-        $phpArgs = implode(' ', array_map("escapeshellarg", self::getPhpArguments()));
+        $phpArgs = implode(' ', array_map('escapeshellarg', self::getPhpArguments()));
         $cmd = escapeshellarg(__DIR__.'/../Resources/bin/build_bootstrap.php');
         $bootstrapDir = escapeshellarg($bootstrapDir);
         $autoloadDir = escapeshellarg($autoloadDir);
@@ -513,7 +513,7 @@ EOF;
     {
         $phpFinder = new PhpExecutableFinder();
 
-        return method_exists($phpFinder, "findArguments") ? $phpFinder->findArguments() : array();
+        return method_exists($phpFinder, 'findArguments') ? $phpFinder->findArguments() : array();
     }
 
     /**


### PR DESCRIPTION
Hi,

When i try to update my dependencies using hhvm (hhvm /usr/local/bin/composer update), i get an error from your script:

sh: 1: /usr/bin/hhvm --php: not found

This is because the --php argument is escaped with the command, this PR fix it (maybe a better way, but i got no time to pend on it)

Thx
