### PR TITLE
Added basic parsing to the check of realpath_cache_size

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -674,7 +674,7 @@ class SymfonyRequirements extends RequirementCollection
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
             $this->addPhpIniRecommendation(
                 'realpath_cache_size',
-                create_function('$cfgValue', 'return (int) $cfgValue > 1000;'),
+                create_function('$cfgValue', 'return (stripos($cfgValue, "k")!==false) || (stripos($cfgValue, "m")!==false) || ((int) $cfgValue > 1000);'),
                 false,
                 'realpath_cache_size should be above 1024 in php.ini',
                 'Set "<strong>realpath_cache_size</strong>" to e.g. "<strong>1024</strong>" in php.ini<a href="#phpini">*</a> to improve performance on windows.'


### PR DESCRIPTION
The existing code has a bug where it does not recognise values that use PHP's 'k' or 'm' syntax, e.g. "5k" = "5000".

To fix this, the pull request adds basic parsing to the realpath_cache_size value check to handle this.

In these cases it will always be at least 1k (i.e. 1000) which is high enough to pass the check, so the function returns true.
