### PR TITLE
Added a new method to generate parameters.yml automatically

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -131,7 +131,9 @@ class ScriptHandler
             return;
         }
 
-        $fs->copy($appDir.'/config/parameters.yml.dist', $appDir.'/config/parameters.yml', true);
+        if (!$fs->exists($appDir.'/config/parameters.yml')) {
+            $fs->copy($appDir.'/config/parameters.yml.dist', $appDir.'/config/parameters.yml', true);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony-standard/issues/691 |
| License | MIT |
| Doc PR | - |

This is the first step into removing the parameter handler when installing Symfony.
