### PR TITLE
Fix override option on acme-bundle creation

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -239,7 +239,7 @@ class ScriptHandler
         $kernelFile = $appDir.'/AppKernel.php';
 
         $fs = new Filesystem();
-        $fs->mirror(__DIR__.'/../Resources/skeleton/acme-demo-bundle', $rootDir.'/src', null, array('override'));
+        $fs->mirror(__DIR__.'/../Resources/skeleton/acme-demo-bundle', $rootDir.'/src', null, array('override' => true));
 
         $ref = '$bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();';
         $bundleDeclaration = "\$bundles[] = new Acme\\DemoBundle\\AcmeDemoBundle();";


### PR DESCRIPTION
FileSystem->mirror function documentation explains this :

Valid options are:
     *                                 - $options['override'] Whether to override an existing file on copy or not (see copy())