### PR TITLE
Hide by default all commands output, except when using -v|-vv|-vvv

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -386,6 +386,10 @@ namespace { return \$loader; }
             $console .= ' --ansi';
         }
 
+        if (!$event->getIO()->isVerbose() && !$event->getIO()->isVeryVerbose() && !$event->getIO()->isDebug()) {
+            $console .= ' --quiet';
+        }
+
         $process = new Process($php.' '.$console.' '.$cmd, null, null, null, $timeout);
         $process->run(function ($type, $buffer) use ($event) { $event->getIO()->write($buffer, false); });
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony-standard/issues/693 |
| License | MIT |
| Doc PR | - |

Let me explain my reasoning for this change to see if I did it right:
- @stof remind us that the best solution is to respect the verbosity settings used when running the Composer command ([see comment](https://github.com/symfony/symfony-standard/issues/693#issuecomment-52482253)).
- In Symfony 2.5 and lower, the commands output their messages, but in 2.6 and higher we want to hide by default all messages.
- As command output only has to be displayed when using `-v` or `-vv` or `-vvv`, I add the `--quiet` option to the command by default and disable it in case you added any of these tree verbosity flags.

As a side note, I'd like to ask you something: when I touch code in this SensioDistribution bundle I always do it blindly. I don't know how to put the pieces together to check that the new code is working right. Any clue about how to test this?
