### PR TITLE
Hide by post-install/update-cmd output unless in verbose mode

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -386,12 +386,19 @@ namespace { return \$loader; }
             $console .= ' --ansi';
         }
 
-        if (!$event->getIO()->isVerbose() && !$event->getIO()->isVeryVerbose() && !$event->getIO()->isDebug()) {
-            $console .= ' --quiet';
-        }
+        $event->getIO()->write(sprintf(
+            'Running the <info>%s %s</info> command',
+            $consoleDir.'/console',
+            $cmd
+        ));
 
         $process = new Process($php.' '.$console.' '.$cmd, null, null, null, $timeout);
-        $process->run(function ($type, $buffer) use ($event) { $event->getIO()->write($buffer, false); });
+        $process->run(function ($type, $buffer) use ($event) {
+            // output the command's output if we have an above-normal verbosity level
+            if ($event->getIO()->isVerbose()) {
+                $event->getIO()->write($buffer, false);
+            }
+        });
         if (!$process->isSuccessful()) {
             throw new \RuntimeException(sprintf('An error occurred when executing the "%s" command.', escapeshellarg($cmd)));
         }


### PR DESCRIPTION
Hi guys!

This follows up with #158. See the description there. This:

A) Doesn't show the output of `assets:install` and `cache:clear` when running composer install/update unless you pass a `-v` or higher

B) Outputs the command being run before running it in all cases.

![screen shot 2014-08-23 at 1 30 47 pm](https://cloud.githubusercontent.com/assets/121003/4021277/bcc24562-2aeb-11e4-8a4d-df7889802a31.png)

![screen shot 2014-08-23 at 1 30 58 pm](https://cloud.githubusercontent.com/assets/121003/4021279/c060886e-2aeb-11e4-801d-bba1f2b787e0.png)

Thanks!
