### PR TITLE
Marked the bundle compatible as compatible with 2.3 again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.3",
         "symfony/class-loader": "~2.2",
         "symfony/form": "~2.2",
         "symfony/process": "~2.2",


### PR DESCRIPTION
The security:check command will not be registered when using the bundle in 2.3, but all other features are working. So the compatibility with the LTS version should be kept.

If we don't keep the compatibility with the LTS, users sticking to it will always ask to backport new changes for Symfony 2.0.3 as they would be stuck to 3.0.2.
Btw, dropping the support of the LTS version in a patch release like 3.0.3 looks wrong to me. It is a change which has a much bigger impact.
