### PR TITLE
Wrong comparison operator in Php.ini requirement check for mbstring.func...

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -533,7 +533,7 @@ class SymfonyRequirements extends RequirementCollection
         if (extension_loaded('mbstring')) {
             $this->addPhpIniRequirement(
                 'mbstring.func_overload',
-                create_function('$cfgValue', 'return (int) $cfgValue !== 0;'),
+                create_function('$cfgValue', 'return (int) $cfgValue === 0;'),
                 true,
                 'string functions should not be overloaded',
                 'Set "<strong>mbstring.func_overload</strong>" to <strong>0</strong> in php.ini<a href="#phpini">*</a> to disable function overloading by the mbstring extension.'


### PR DESCRIPTION
..._overload

Throwing a 'Major Problem' warning with "Set mbstring.func_overload to 0 in php.ini\* to disable function overloading by the mbstring extension." when mbstring.func_overload is actually set to 0 in php.ini. Wrong comparison operator?
