### PR TITLE
as per feature feature #174. correction of mbstring.func_overload check....

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -533,7 +533,7 @@ class SymfonyRequirements extends RequirementCollection
         if (extension_loaded('mbstring')) {
             $this->addPhpIniRequirement(
                 'mbstring.func_overload',
-                create_function('$cfgValue', 'return (int) $cfgValue !== 0;'),
+                create_function('$cfgValue', 'return (int) $cfgValue === 0;'),
                 true,
                 'string functions should not be overloaded',
                 'Set "<strong>mbstring.func_overload</strong>" to <strong>0</strong> in php.ini<a href="#phpini">*</a> to disable function overloading by the mbstring extension.'


### PR DESCRIPTION
... This requirement is fulfilled when value is equal/identical to 0 and not different
