### PR TITLE
Symfony requirement for the realpath_cache_size works with string values

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -682,10 +682,8 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-            $this->addPhpIniRecommendation(
-                'realpath_cache_size',
-                create_function('$cfgValue', 'return (int) $cfgValue > 1000;'),
-                false,
+            $this->addRecommendation(
+                $this->getRealpathCacheSize() > 1000,
                 'realpath_cache_size should be above 1024 in php.ini',
                 'Set "<strong>realpath_cache_size</strong>" to e.g. "<strong>1024</strong>" in php.ini<a href="#phpini">*</a> to improve performance on windows.'
             );
@@ -712,6 +710,30 @@ class SymfonyRequirements extends RequirementCollection
                 sprintf('PDO should have some drivers installed (currently available: %s)', count($drivers) ? implode(', ', $drivers) : 'none'),
                 'Install <strong>PDO drivers</strong> (mandatory for Doctrine).'
             );
+        }
+    }
+
+    /**
+     * Loads realpath_cache_size from php.ini and converts it to int.
+     *
+     * (e.g. 16k is converted to 16384 int)
+     *
+     * @return int
+     */
+    protected function getRealpathCacheSize()
+    {
+        $size = ini_get('realpath_cache_size');
+        $size = trim($size);
+        $unit = strtolower(substr($size, -1, 1));
+        switch ($unit) {
+            case 'g':
+                return $size * 1024 * 1024 * 1024;
+            case 'm':
+                return $size * 1024 * 1024;
+            case 'k':
+                return $size * 1024;
+            default:
+                return (int) $size;
         }
     }
 }


### PR DESCRIPTION
`realpath_cache_size` can be set using so-called _string values_ (such as `16K`)
(see http://php.net/manual/en/ini.core.php#ini.sect.performance - default is `16K`)

**Problem**: When such value is detected and compared to 1024 after its conversion to int, it fails although the value is fine for Symfony.

**Solution**: This PR adds a conversion function based on what http://php.net/manual/en/function.ini-get.php recommends.

Original PR: https://github.com/sensiolabs/SensioDistributionBundle/pull/106
Original commit: https://github.com/sensiolabs/SensioDistributionBundle/commit/cf0179711b24d84d4a29d71a4010540f4c990bd8
Related: https://github.com/sensiolabs/SensioDistributionBundle/issues/172, https://github.com/sensiolabs/SensioDistributionBundle/pull/153
