### PR TITLE
[DistributionBundle] Fix real vendor dir , reading from composer.json file

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -744,13 +744,13 @@ class SymfonyRequirements extends RequirementCollection
      *
      * @return string
      */
-    protected function getComposerVendorDir()
+    private function getComposerVendorDir()
     {
-        $composerJson = json_decode(file_get_contents(__DIR__."/../composer.json"));
-        if(isset($composerJson->config)) {
+        $composerJson = json_decode(file_get_contents(__DIR__.'/../composer.json'));
+        if (isset($composerJson->config)) {
             return $composerJson->config->{'vendor-dir'};
         }
-        
+
         return __DIR__.'/../vendor/composer';
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [-] |
| Fixed tickets | #184 |
| License | MIT |
| Doc PR | [] |

Couldnt find the test, I tested manually replacing the SymfonyRequirements in a 2.6 distribution.
It's my first PR, so, i hope this can help. Thanks.
