### PR TITLE
fix , now get reals composer vendor folder or default, and check if

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -403,7 +403,7 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         $this->addRequirement(
-            is_dir($this->getComposerVendorDir()),
+            is_dir($this->getComposerVendorDir()."/composer"),
             'Vendor libraries must be installed',
             'Vendor libraries are missing. Install composer following instructions from <a href="http://getcomposer.org/">http://getcomposer.org/</a>. '.
                 'Then run "<strong>php composer.phar install</strong>" to install them.'
@@ -751,6 +751,6 @@ class SymfonyRequirements extends RequirementCollection
             return $composerJson->config->{'vendor-dir'};
         }
 
-        return __DIR__.'/../vendor/composer';
+        return __DIR__.'/../vendor';
     }
 }

--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -747,7 +747,7 @@ class SymfonyRequirements extends RequirementCollection
     private function getComposerVendorDir()
     {
         $composerJson = json_decode(file_get_contents(__DIR__.'/../composer.json'));
-        if (isset($composerJson->config)) {
+        if (isset($composerJson->config) && isset($composerJson->config->{'vendor-dir'})) {
             return $composerJson->config->{'vendor-dir'};
         }
 

--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -747,9 +747,9 @@ class SymfonyRequirements extends RequirementCollection
     private function getComposerVendorDir()
     {
         $composerVendorDir = "vendor";
-        $composerJson = json_decode(file_get_contents(__DIR__.'/../composer.json'));
-        if (isset($composerJson->config) && isset($composerJson->config->{'vendor-dir'})) {
-            $composerVendorDir = $composerJson->config->{'vendor-dir'};
+        $composerJson = json_decode(file_get_contents(__DIR__.'/../composer.json'),true);
+        if (isset($composerJson["config"]["vendor-dir"])) {
+            $composerVendorDir = $composerJson["config"]["vendor-dir"];
             if (realpath($composerVendorDir) == $composerVendorDir) { //is absolute
                 return $composerVendorDir;
             }

--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -742,15 +742,19 @@ class SymfonyRequirements extends RequirementCollection
      * root directory. To make this command work for every case, read Composer's
      * vendor/ directory location directly from composer.json file.
      *
-     * @return string
+     * @return string Absolute path to vendor directory
      */
     private function getComposerVendorDir()
     {
+        $composerVendorDir = "vendor";
         $composerJson = json_decode(file_get_contents(__DIR__.'/../composer.json'));
         if (isset($composerJson->config) && isset($composerJson->config->{'vendor-dir'})) {
-            return $composerJson->config->{'vendor-dir'};
+            $composerVendorDir = $composerJson->config->{'vendor-dir'};
+            if (realpath($composerVendorDir) == $composerVendorDir) { //is absolute
+                return $composerVendorDir;
+            }
         }
 
-        return __DIR__.'/../vendor';
+        return realpath(__DIR__.'/../'.$composerVendorDir);
     }
 }


### PR DESCRIPTION
Fix the getComposerVendorDir() method, and check if really the composer folder exists inside it.
Based on:
https://github.com/sensiolabs/SensioDistributionBundle/issues/186#issuecomment-68428965
Related to the original: https://github.com/sensiolabs/SensioDistributionBundle/pull/185