### PR TITLE
prepareDeploymentTarget script handler

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -44,6 +44,29 @@ class ScriptHandler
     }
 
     /**
+     * Sets up deployment target specific features.
+     * Could be custom web server configs, boot command files etc.
+     *
+     * @param $event CommandEvent An instance
+     */
+    public static function prepareDeploymentTarget(CommandEvent $event)
+    {
+        self::prepareDeploymentTargetHeroku($event);
+    }
+
+    protected static function prepareDeploymentTargetHeroku(CommandEvent $event)
+    {
+        $options = self::getOptions($event);
+        if (($stack = getenv('STACK')) && ($stack == 'cedar' || $stack == 'cedar-14')) {
+            $fs = new Filesystem();
+            if (!$fs->exists('Procfile')) {
+                $event->getIO()->write('Heroku deploy detected; creating default Procfile for "web" dyno');
+                $fs->dumpFile('Procfile', sprintf('web: $(composer config bin-dir)/heroku-php-apache2 %s/', $options['symfony-web-dir']));
+            }
+        }
+    }
+
+    /**
      * Clears the Symfony cache.
      *
      * @param $event CommandEvent A instance


### PR DESCRIPTION
So far handles Heroku.

Uses `$STACK` to detect cedar/cedar-14 builds and writes a `Procfile` with the boot command for the correct document root if no `Procfile` exists.

Needs `Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap` in `post-install-cmd`.

cc @fabpot