### PR TITLE
Readded Doctrine binaries in the ZIP file and fixed them for the TGZ file

### DIFF
--- a/Resources/bin/build.sh
+++ b/Resources/bin/build.sh
@@ -60,8 +60,8 @@ cd /tmp/Symfony
 TARGET=/tmp/Symfony/vendor
 
 # Doctrine
-cd $TARGET/doctrine/orm && rm -rf UPGRADE* build* bin tests tools lib/vendor
-cd $TARGET/doctrine/dbal && rm -rf bin build* tests lib/vendor
+cd $TARGET/doctrine/orm && rm -rf UPGRADE* build* tests tools lib/vendor
+cd $TARGET/doctrine/dbal && rm -rf build* tests lib/vendor
 cd $TARGET/doctrine/common && rm -rf build* tests lib/vendor
 if [ -d $TARGET/doctrine/doctrine-bundle/Doctrine/Bundle/DoctrineBundle ]; then
     cd $TARGET/doctrine/doctrine-bundle/Doctrine/Bundle/DoctrineBundle && rm -rf Tests Resources/doc
@@ -114,6 +114,7 @@ find $TARGET -name .gitignore | xargs rm -rf -
 find $TARGET -name .gitmodules | xargs rm -rf -
 find $TARGET -name .svn | xargs rm -rf -
 
+# With vendors
 cd /tmp
 tar zcpf $DIR/Symfony_Standard_Vendors_$VERSION.tgz Symfony
 sudo rm -f $DIR/Symfony_Standard_Vendors_$VERSION.zip


### PR DESCRIPTION
When using the Symfony installer, the Doctrine binaries were missing in the ZIP file and were broken in the TGZ file. This simple change brings those binaries back for both versions:

![new_symfony_contents](https://cloud.githubusercontent.com/assets/73419/6410130/73d078e6-be6c-11e4-896f-b793dc5a5b49.png)

This fixes https://github.com/symfony/symfony-installer/issues/107