### PR TITLE
Removed AcmeDemoBundle from the regular Symfony distribution

### DIFF
--- a/Resources/bin/build_demo.sh
+++ b/Resources/bin/build_demo.sh
@@ -27,24 +27,26 @@ fi
 # avoid the creation of ._* files
 export COPY_EXTENDED_ATTRIBUTES_DISABLE=true
 export COPYFILE_DISABLE=true
-export SENSIOLABS_FORCE_ACME_DEMO=true
 
 # Temp dir
 rm -rf /tmp/Symfony
 mkdir /tmp/Symfony
 
-# Create project
-composer create-project -n symfony/framework-standard-edition /tmp/Symfony
-
+# Clone project and install dependencies
+git clone https://github.com/symfony/symfony-demo /tmp/Symfony
 cd /tmp/Symfony
+composer install --prefer-dist --quiet --no-interaction --no-scripts --ignore-platform-reqs --no-plugins --optimize-autoloader
 
 # cleanup
+cd /tmp/Symfony
 sudo rm -f UPGRADE*
+sudo mv .gitignore keep.gitignore
 sudo rm -rf app/cache/* app/logs/* .git*
+sudo mv keep.gitignore .gitignore
 chmod 777 app/cache app/logs
 find . -name .DS_Store | xargs rm -rf -
 
-# With vendors
+# remove unneded dependencies files
 cd /tmp/Symfony
 TARGET=/tmp/Symfony/vendor
 
@@ -97,12 +99,14 @@ fi
 cd $TARGET/twig/twig && rm -rf AUTHORS CHANGELOG README.markdown bin doc package.xml.tpl phpunit.xml* test
 cd $TARGET/twig/extensions && rm -rf README doc phpunit.xml* test
 
-# cleanup
+# final cleanup
 find $TARGET -name .git | xargs rm -rf -
 find $TARGET -name .gitignore | xargs rm -rf -
 find $TARGET -name .gitmodules | xargs rm -rf -
 find $TARGET -name .svn | xargs rm -rf -
 
+# build ZIP and TGZ packages
 cd /tmp
+tar zcpf $DIR/Symfony_Demo.tgz Symfony
 sudo rm -f $DIR/Symfony_Demo.zip
 zip -rq $DIR/Symfony_Demo.zip Symfony

--- a/Resources/bin/build_demo.sh
+++ b/Resources/bin/build_demo.sh
@@ -12,11 +12,6 @@ if [ ! $1 ]; then
     exit 1
 fi
 
-if [ ! $2 ]; then
-    echo "\033[37;41mYou must pass the version to build\033[0m"
-    exit 1
-fi
-
 DIR=$1
 CURRENT=`php -r "echo realpath(dirname(\\$_SERVER['argv'][0]));"`
 
@@ -32,27 +27,22 @@ fi
 # avoid the creation of ._* files
 export COPY_EXTENDED_ATTRIBUTES_DISABLE=true
 export COPYFILE_DISABLE=true
+export SENSIOLABS_FORCE_ACME_DEMO=true
 
 # Temp dir
 rm -rf /tmp/Symfony
 mkdir /tmp/Symfony
 
 # Create project
-composer create-project -n symfony/framework-standard-edition /tmp/Symfony $2
-
-if [ 0 -ne $? ]; then
-    echo "\033[37;41mVersion $2 does not exist\033[0m"
-    exit 1
-fi
+composer create-project -n symfony/framework-standard-edition /tmp/Symfony
 
 cd /tmp/Symfony
 
 # cleanup
+sudo rm -f UPGRADE*
 sudo rm -rf app/cache/* app/logs/* .git*
 chmod 777 app/cache app/logs
 find . -name .DS_Store | xargs rm -rf -
-
-VERSION=`grep ' VERSION ' vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php | sed -E "s/.*'(.+)'.*/\1/g"`
 
 # With vendors
 cd /tmp/Symfony
@@ -114,13 +104,5 @@ find $TARGET -name .gitmodules | xargs rm -rf -
 find $TARGET -name .svn | xargs rm -rf -
 
 cd /tmp
-tar zcpf $DIR/Symfony_Standard_Vendors_$VERSION.tgz Symfony
-sudo rm -f $DIR/Symfony_Standard_Vendors_$VERSION.zip
-zip -rq $DIR/Symfony_Standard_Vendors_$VERSION.zip Symfony
-
-# Without vendors
-cd /tmp
-rm -rf Symfony/vendor
-tar zcpf $DIR/Symfony_Standard_$VERSION.tgz Symfony
-sudo rm -f $DIR/Symfony_Standard_$VERSION.zip
-zip -rq $DIR/Symfony_Standard_$VERSION.zip Symfony
+sudo rm -f $DIR/Symfony_Demo.zip
+zip -rq $DIR/Symfony_Demo.zip Symfony


### PR DESCRIPTION
## The problem

The new Symfony Installer downloads the Symfony packages created with these scripts. The problem is that they include the AcmeDemoBundle which all non-newcomer Symfony developers want to remove.

## The proposed solution

  * The AcmeDemoBundle is no longer included in the regular Symfony distribution. This way the installer creates a fresh and empty Symfony application. This is the last feature to finish the installer.
  * A new script (`build_demo.sh`) creates a new `Symfony_Demo.zip` file which contains the latest stable version of Symfony and the AcmeDemoBundle. This is the package that we'd promote for newcomers and it would allow us to improve the AcmeDemoBundle to include more features and better explanations.