### PR TITLE
Silence deprecation notices

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -192,7 +192,10 @@ class ScriptHandler
 
         file_put_contents($file, sprintf("<?php
 
-namespace { \$loader = require_once __DIR__.'/autoload.php'; }
+namespace {
+    error_reporting(error_reporting() & ~E_USER_DEPRECATED);
+    \$loader = require_once __DIR__.'/autoload.php';
+}
 
 %s
 


### PR DESCRIPTION
In Symfony 2.7, we should silence by default the deprecation notices that are triggered.
In debug, this is overwritten by Debug::enable() in app_dev.php