### PR TITLE
[2.3] [bugfix] fixed new line at EOF while generating bootstrap.php.cache

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -190,17 +190,20 @@ class ScriptHandler
 
         ClassCollectionLoader::load($classes, dirname($file), basename($file, '.php.cache'), false, false, '.php.cache');
 
-        file_put_contents($file, sprintf("<?php
+        file_put_contents($file, sprintf(<<<'EOF'
+<?php
 
 namespace {
     error_reporting(error_reporting() & ~E_USER_DEPRECATED);
-    \$loader = require_once __DIR__.'/autoload.php';
+    $loader = require_once __DIR__.'/autoload.php';
 }
 
 %s
 
-namespace { return \$loader; }
-            ", substr(file_get_contents($file), 5)));
+namespace { return $loader; }
+
+EOF
+            , substr(file_get_contents($file), 5)));
     }
 
     protected static function executeCommand(CommandEvent $event, $appDir, $cmd, $timeout = 300)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #202
| License       | MIT
| Doc PR        | n/a

fixes #202