### PR TITLE
Fixed bug in checking edge case intl problem

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -625,16 +625,15 @@ class SymfonyRequirements extends RequirementCollection
             'Install and enable the <strong>intl</strong> extension (used for validators).'
         );
 
-        if (class_exists('Collator') && extension_loaded('intl')) {
+        if (extension_loaded('intl')) {
             // in some WAMP server installations, new Collator() returns null
             $this->addRecommendation(
                 null !== new Collator('fr_FR'),
                 'intl extension should be correctly configured',
                 'The intl extension does not behave properly. This problem is typical on PHP 5.3.X x64 WIN builds.'
             );
-        }
 
-        if (class_exists('Locale')) {
+            // check for compatible ICU versions (only done when you have the intl extension)
             if (defined('INTL_ICU_VERSION')) {
                 $version = INTL_ICU_VERSION;
             } else {

--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -626,11 +626,18 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         if (class_exists('Collator')) {
-            $this->addRecommendation(
-                null !== new Collator('fr_FR'),
-                'intl extension should be correctly configured',
-                'The intl extension does not behave properly. This problem is typical on PHP 5.3.X x64 WIN builds.'
-            );
+            try {
+                // in some WAMP server installations, new Collator() returns null
+                $this->addRecommendation(
+                    null !== new Collator('fr_FR'),
+                    'intl extension should be correctly configured',
+                    'The intl extension does not behave properly. This problem is typical on PHP 5.3.X x64 WIN builds.'
+                );
+            } catch (Symfony\Component\Intl\Exception\ExceptionInterface $e) {
+                // if an exception is thrown from the Intl component is thrown
+                // then they don't have intl installed at all, and we've warned
+                //them about this already
+            }
         }
 
         if (class_exists('Locale')) {

--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -626,18 +626,12 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         if (class_exists('Collator')) {
-            try {
-                // in some WAMP server installations, new Collator() returns null
-                $this->addRecommendation(
-                    null !== new Collator('fr_FR'),
-                    'intl extension should be correctly configured',
-                    'The intl extension does not behave properly. This problem is typical on PHP 5.3.X x64 WIN builds.'
-                );
-            } catch (Symfony\Component\Intl\Exception\ExceptionInterface $e) {
-                // if an exception is thrown from the Intl component is thrown
-                // then they don't have intl installed at all, and we've warned
-                //them about this already
-            }
+            // in some WAMP server installations, new Collator() returns null
+            $this->addRecommendation(
+                !(extension_loaded('intl') && null !== new Collator('fr_FR')),
+                'intl extension should be correctly configured',
+                'The intl extension does not behave properly. This problem is typical on PHP 5.3.X x64 WIN builds.'
+            );
         }
 
         if (class_exists('Locale')) {

--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -625,10 +625,10 @@ class SymfonyRequirements extends RequirementCollection
             'Install and enable the <strong>intl</strong> extension (used for validators).'
         );
 
-        if (class_exists('Collator')) {
+        if (class_exists('Collator') && extension_loaded('intl')) {
             // in some WAMP server installations, new Collator() returns null
             $this->addRecommendation(
-                !(extension_loaded('intl') && null !== new Collator('fr_FR')),
+                null !== new Collator('fr_FR'),
                 'intl extension should be correctly configured',
                 'The intl extension does not behave properly. This problem is typical on PHP 5.3.X x64 WIN builds.'
             );


### PR DESCRIPTION
Hi guys!

See the following issues. I opened this against 2.3, because the SE for 2.3 includes this bundle at `~2.3` (and I want the fix to work for it).

* symfony/symfony-installer#163
* sensiolabs/SensioDistributionBundle#48
* sensiolabs/SensioDistributionBundle#59

@javiereguiluz can you test this? I haven't had success disabling my intl extension yet, and you were able to repeat the bug.

What happens is:

* The `intl` extension isn't loaded
* The stub `Collator` from the `Intl` component is used instead
* When you instantiate this, it throws an exception for any locale other than `en`

But I don't know *when* this was introduced - the stub `Collator` always worked like this - at least back to 2.3.0, and I have a hard time believing that people have gotten this error since then :). I'm also not sure about the check about this (`class_exists('Locale')`) - it seems that this class will always exist, because of the stub `Locale` class in the `Intl` component. Am I mis-reading?

But most importantly - if this fixes the issue, we should merge. If I've located additional issues in my paragraph above, then let's fix those later.

Thanks!