### PR TITLE
Pass the file to the YAML parser, not the filename

### DIFF
--- a/Configurator/Configurator.php
+++ b/Configurator/Configurator.php
@@ -200,7 +200,7 @@ class Configurator
             $filename = $this->getCacheFilename();
         }
 
-        $ret = Yaml::parse($filename);
+        $ret = Yaml::parse(file_get_contents($filename));
         if (false === $ret || array() === $ret) {
             throw new \InvalidArgumentException(sprintf('The %s file is not valid.', $filename));
         }


### PR DESCRIPTION
The ability to pass file names to the Symfony\Component\Yaml\Yaml::parse method is deprecated since version 2.2 and will be removed in 3.0.