### PR TITLE
Clean the composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,25 +12,16 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/framework-bundle": "~2.3",
+        "symfony/dependency-injection": "~2.3",
+        "symfony/config": "~2.3",
+        "symfony/filesystem": "~2.3",
         "symfony/class-loader": "~2.2",
         "symfony/process": "~2.2",
         "sensiolabs/security-checker": "~2.0"
     },
-    "require-dev": {
-        "symfony/form": "~2.2",
-        "symfony/validator": "~2.2",
-        "symfony/yaml": "~2.2"
-    },
-    "suggest": {
-        "symfony/form": "If you want to use the configurator",
-        "symfony/validator": "If you want to use the configurator",
-        "symfony/yaml": "If you want to use  the configurator"
-    },
     "autoload": {
-        "psr-0": { "Sensio\\Bundle\\DistributionBundle": "" }
+        "psr-4": { "Sensio\\Bundle\\DistributionBundle\\": "" }
     },
-    "target-dir": "Sensio/Bundle/DistributionBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "5.0.x-dev"


### PR DESCRIPTION
Given the webconfigurator has been removed from the bundle, most of the dependencies are not needed anymore.