### PR TITLE
Don't include ContainerAwareHttpKernel if it's not present

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -277,8 +277,10 @@ class ScriptHandler
         $autoloaders = spl_autoload_functions();
         if (is_array($autoloaders[0]) && method_exists($autoloaders[0][0], 'findFile') && $autoloaders[0][0]->findFile('Symfony\\Bundle\\FrameworkBundle\\HttpKernel')) {
             $classes[] = 'Symfony\\Bundle\\FrameworkBundle\\HttpKernel';
-        } else {
+        } elseif (is_array($autoloaders[0]) && method_exists($autoloaders[0][0], 'findFile') && $autoloaders[0][0]->findFile('Symfony\\Component\\HttpKernel\\DependencyInjection\\ContainerAwareHttpKernel')) {
             $classes[] = 'Symfony\\Component\\HttpKernel\\DependencyInjection\\ContainerAwareHttpKernel';
+        } else {
+            $classes[] = 'Symfony\\Component\\HttpKernel\\HttpKernel';
         }
 
         ClassCollectionLoader::load($classes, dirname($file), basename($file, '.php.cache'), false, false, '.php.cache');


### PR DESCRIPTION
When generating the bootstrap file, the composer script handler also includes `Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel`, a class that has been removed with PR symfony/symfony#14634 and that will be gone in Symfony 3.0.

This pull request checks if the class is present and includes `Symfony\Component\HttpKernel\HttpKernel` otherwise. The code should work with Symfony 2.7 as well as with 3.0-dev.