### PR TITLE
remove autoloading from bootstrap file

### DIFF
--- a/Resources/bin/build_bootstrap.php
+++ b/Resources/bin/build_bootstrap.php
@@ -56,4 +56,4 @@ if (null === $bootstrapDir) {
 require_once $autoloadDir.'/autoload.php';
 
 // here we pass realpaths as resolution between absolute and relative path can be wrong
-ScriptHandler::doBuildBootstrap($bootstrapDir, $autoloadDir, $useNewDirectoryStructure);
+ScriptHandler::doBuildBootstrap($bootstrapDir);


### PR DESCRIPTION
Continuation of https://github.com/symfony/symfony-standard/pull/854 to remove the obsolete mix of bootstrap and autoloading.

@fabpot it would be good to merge this in 5.0, even if you just created the first relase of it. 5.x is also the dependency in the standard edition now.