### PR TITLE
Increased required realpath_cache_size on Windows

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -725,9 +725,9 @@ class SymfonyRequirements extends RequirementCollection
 
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
             $this->addRecommendation(
-                $this->getRealpathCacheSize() > 1000,
-                'realpath_cache_size should be above 1024 in php.ini',
-                'Set "<strong>realpath_cache_size</strong>" to e.g. "<strong>1024</strong>" in php.ini<a href="#phpini">*</a> to improve performance on windows.'
+                $this->getRealpathCacheSize() > 5 * 1024 * 1024,
+                'realpath_cache_size should be above 5242880 in php.ini',
+                'Setting "<strong>realpath_cache_size</strong>" to e.g. "<strong>5242880</strong>" or "<strong>5000k</strong>" in php.ini<a href="#phpini">*</a> may improve performance on Windows significantly in some cases.'
             );
         }
 


### PR DESCRIPTION
Incorrectly set `realpath_cache_size` causes big speed degradation on Windows systems (like really big!).

The realpath_cache_size in the `php.ini` is *total number of bytes in the path strings stored + metadata* (see http://php.net/manual/en/ini.core.php#ini.realpath-cache-size).
So if the requirement is set to 1024 (which means 1024B), only 10-20 paths would fit there.

Just to get some idea about optimal value, I set really high limit in `php.ini` and added `realpath_cache_size()` call in the `BlogController` of  the Symfony demo app (it fetches the currently used cache size). The value fluctuated around 500 000. Homepage of Sylius consumed around 1 500 000. As I had those var_dumps in the controller, more was probably consumed during the request. Therefore, I suggest using 5000k as a recommended value. It should be enough for even big Symfony projects.

I did just a very basic performance testing with admin of Symfony demo app:
* with `realpath_cache_size` set to 1000 takes 500-600ms to load
* with `realpath_cache_size` set to 5000k takes 100-200ms to load
(tested only with browser, changed the value in php.ini, restarted Apache)

And with Sylius homepage:
* with `realpath_cache_size` set to 1000 takes 16s to load (yeah, seconds)
* with `realpath_cache_size` set to 5000k takes 2s to load


Furthermore, I suggest, that we change this check into "error" instead of warning, because now the requirements checker says that everything is fine and you might want to fine-tune other settings. (Or we can split the check into two, one as error with lower limit, like 500k and second will be recommendation with 5000k)

Related:
* original PR https://github.com/sensiolabs/SensioDistributionBundle/pull/106
* original issue https://github.com/symfony/symfony/issues/9189