### PR TITLE
Don't remove Symfony's .gitignore when creating packages

### DIFF
--- a/Resources/bin/build.sh
+++ b/Resources/bin/build.sh
@@ -49,7 +49,7 @@ fi
 cd /tmp/Symfony
 
 # cleanup
-rm -rf app/cache/* app/logs/* .git*
+rm -rf app/cache/* app/logs/* .git/
 chmod 777 app/cache app/logs
 find . -name .DS_Store | xargs rm -rf -
 
@@ -113,7 +113,6 @@ cd $TARGET/twig/twig && rm -rf AUTHORS CHANGELOG README.markdown bin doc package
 
 # cleanup
 find $TARGET -name .git | xargs rm -rf -
-find $TARGET -name .gitignore | xargs rm -rf -
 find $TARGET -name .gitmodules | xargs rm -rf -
 find $TARGET -name .svn | xargs rm -rf -
 

--- a/Resources/bin/build_demo.sh
+++ b/Resources/bin/build_demo.sh
@@ -41,7 +41,7 @@ composer install --prefer-dist --no-interaction --ignore-platform-reqs --no-plug
 cd /tmp/Symfony
 rm -f UPGRADE*
 mv .gitignore keep.gitignore
-rm -rf app/cache/* app/logs/* .git*
+rm -rf app/cache/* app/logs/* .git/
 mv keep.gitignore .gitignore
 chmod 777 app/cache app/logs
 find . -name .DS_Store | xargs rm -rf -
@@ -101,7 +101,6 @@ cd $TARGET/twig/extensions && rm -rf README doc phpunit.xml* test
 
 # final cleanup
 find $TARGET -name .git | xargs rm -rf -
-find $TARGET -name .gitignore | xargs rm -rf -
 find $TARGET -name .gitmodules | xargs rm -rf -
 find $TARGET -name .svn | xargs rm -rf -
 


### PR DESCRIPTION
1. Some people have reported issue with the Symfony Installer because the `.gitignore` file is not 100% correct.
2. The `.gitignore` is created by the Installer itself after unpacking the Symfony ZIP file.
3. We have to do that because this SensioDistributionBundle removes the original .gitignore file.
4. This PR tries to preserve the original `.gitignore` file.