### PR TITLE
Fixed root path since moving to PSR-4 autoloading.

### DIFF
--- a/Resources/bin/build_bootstrap.php
+++ b/Resources/bin/build_bootstrap.php
@@ -42,7 +42,7 @@ if (!empty($argv[3])) {
     $useNewDirectoryStructure = true;
 }
 
-$rootDir = __DIR__.'/../../../../../../../..';
+$rootDir = __DIR__.'/../../../../..';
 if (null === $autoloadDir) {
     $autoloadDir = getRealpath($rootDir.'/app', 'Looks like you don\'t have a standard layout.');
 }


### PR DESCRIPTION
In the current master and also in tags `~5.0.0` I get:

```php
$ ./vendor/sensio/distribution-bundle/Resources/bin/build_bootstrap.php app/
Looks like you don't have a standard layout.
```

Because `build_bootstrap.php` is located in `/vendor/sensio/distribution-bundle/Resources/bin/build_bootstrap.php` and not in `/vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php` as in `<=4.0`