### PR TITLE
Fix the size of the background-colored block

### DIFF
--- a/Resources/skeleton/app/check.php
+++ b/Resources/skeleton/app/check.php
@@ -120,10 +120,14 @@ function echo_block($style, $title, $message)
 
     echo PHP_EOL.PHP_EOL;
 
-    echo_style($style, str_repeat(' ', $width).PHP_EOL);
-    echo_style($style, str_pad(' ['.$title.']', $width, ' ', STR_PAD_RIGHT).PHP_EOL);
-    echo_style($style, str_pad($message, $width, ' ', STR_PAD_RIGHT).PHP_EOL);
-    echo_style($style, str_repeat(' ', $width).PHP_EOL);
+    echo_style($style, str_repeat(' ', $width));
+    echo PHP_EOL;
+    echo_style($style, str_pad(' ['.$title.']', $width, ' ', STR_PAD_RIGHT));
+    echo PHP_EOL;
+    echo_style($style, $message);
+    echo PHP_EOL;
+    echo_style($style, str_repeat(' ', $width));
+    echo PHP_EOL;
 }
 
 function has_color_support()


### PR DESCRIPTION
Hi,

When I run the command ``./bin/symfony_requirements``, I found that the size of the ERROR/OK blocks is too wide, and the extra line of each block is glued to the next title.

This PR will fix the background-colored block, as you can see on the screenshots.

#### Current
##### ERROR
![before_error](https://cloud.githubusercontent.com/assets/6303296/11917401/e18705bc-a705-11e5-9f0f-1f3206c7ca73.png)
##### OK
![before_ok](https://cloud.githubusercontent.com/assets/6303296/11917402/e1892d1a-a705-11e5-82d5-dc9263c10bd4.png)

#### With the fix
##### ERROR
![after_error](https://cloud.githubusercontent.com/assets/6303296/11917399/e1608112-a705-11e5-917b-e5eef0c3b007.png)
##### OK
![after_ok](https://cloud.githubusercontent.com/assets/6303296/11917400/e185335e-a705-11e5-853f-aa85e53670eb.png)

What do you think about it?