### PR TITLE
Remove troublesome unlink() call

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -354,9 +354,6 @@ EOF;
     public static function doBuildBootstrap($bootstrapDir, $autoloadDir = null, $useNewDirectoryStructure = false)
     {
         $file = $bootstrapDir.'/bootstrap.php.cache';
-        if (file_exists($file)) {
-            unlink($file);
-        }
 
         $classes = array(
             'Symfony\\Component\\HttpFoundation\\ParameterBag',


### PR DESCRIPTION
After a recent update to Windows 8.1, I was no longer able to execute any command which resulted in the bootstrap cache file being built.

The most common occurrence of this was post composer update/install commands.

Project details:

Symfony: 2.6.12
Sensio Distribution Bundle: v3.0.34
PHP: 5.3.3
Windows: 6.3 (Build 9600)

The issue seems to stem from the "unlink" command.  I am not acutely familiar with the intricacies of Windows file-handling systems, or how php interacts with them, but prior to the removal of the unlink statement, the following would always occur:

```
C:\apache\htdocs\projects\{prjdir}>composer run-script post-update-cmd
> Incenteev\ParameterHandler\ScriptHandler::buildParameters
Updating the "app/config/parameters.yml" file
> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::buildBootstrap

Warning: file_put_contents(C:\apache\htdocs\projects\{prjdir}\app/bootstrap.php.cache): failed to open stream: Invalid argument in C:\apache\htdocs\proj
ects\{prjdir}\vendor\sensio\distribution-bundle\Sensio\Bundle\DistributionBundle\Composer\ScriptHandler.php on line 424

Call Stack:
    0.0002     340848   1. {main}() C:\apache\htdocs\projects\{prjdir}\vendor\sensio\distribution-bundle\Sensio\Bundle\DistributionBundle\Resources\bin\
build_bootstrap.php:0
    0.0044     781344   2. Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::doBuildBootstrap() C:\apache\htdocs\projects\{prjdir}\vendor\sensio\
distribution-bundle\Sensio\Bundle\DistributionBundle\Resources\bin\build_bootstrap.php:59
    0.3106    3056712   3. file_put_contents() C:\apache\htdocs\projects\{prjdir}\vendor\sensio\distribution-bundle\Sensio\Bundle\DistributionBundle\Com
poser\ScriptHandler.php:424

> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache

Fatal error: Class 'Symfony\Component\Console\Input\ArgvInput' not found in C:\apache\htdocs\projects\{prjdir}\app\console on line 20

Call Stack:
    0.0002     336960   1. {main}() C:\apache\htdocs\projects\{prjdir}\app\console:0

Script Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache handling the post-update-cmd event terminated with an exception



  [RuntimeException]
  An error occurred when executing the ""cache:clear --no-warmup"" command:
  Fatal error: Class 'Symfony\Component\Console\Input\ArgvInput' not found in C:\apache\htdocs\projects\{prjdir}\app\console on line 20
  Call Stack:
      0.0002     336960   1. {main}() C:\apache\htdocs\projects\{prjdir}\app\console:0
  .



run-script [--dev] [--no-dev] [-l|--list] [--] [<script>] [<args>]...



C:\apache\htdocs\projects\{prjdir}>
```

Best guess is whatever process is handling the removal of the file has the potential to not yet be completed by the time the write statement happens.

I also question this statements need in the first place.  The `file_put_contents` command will truncate the file prior to writing unless the `FILE_APPEND` argument is passed in, anyway.  Is it to update the created timestamp?