### PR TITLE
Added an upgrade file for 5.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,14 @@
+UPGRADE FROM 4.0 to 5.0
+=======================
+
+   * The web configurator got removed. So you need to remove the `_configurator`
+     routing entry from `app/config/routing_dev.yml`.
+
+   * The generated `app/bootstrap.php.cache` does not include autoloading anymore.
+     So you need to add the autoloading code in your front controllers `web/app.php`,
+     `web/app_dev.php`, `app/console` and `app/phpunit.xml.dist` (bootstrap config).
+
+   * If you have been using the Symfony 3 directory structure already, you need to
+     overwrite the cache and log directories in your `AppKernel` as it is also done
+     in Symfony 3 now (see
+     [`app/AppKernel.php`](https://github.com/symfony/symfony-standard/blob/master/app/AppKernel.php#L31-L44)).


### PR DESCRIPTION
As I've not been very active in upgrade this package, I had to go from 3.0 to 5.0 and I encountered this issue. I tried to find out what was broken and got back to [this commit](https://github.com/sensiolabs/SensioDistributionBundle/commit/b6fd439d2afe45f8f73981e8bf9ff5d2891c0830). To save people some time, I've added the upgrade-5.0 file with this change documented.

I'm not sure if this change was introduced in 5.0.0 or a later patch version but it's a BC break nevertheless.

/cc @Tobion 