### PR TITLE
Add Symfony environment to commands executed in ScriptHandler

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -434,8 +434,8 @@ EOF;
     /**
      * Returns a relative path to the directory that contains the `console` command.
      *
-     * @param Event $event      The command event.
-     * @param string       $actionName The name of the action
+     * @param Event  $event      The command event.
+     * @param string $actionName The name of the action
      *
      * @return string|null The path to the console directory, null if not found.
      */

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -27,13 +27,13 @@ class ScriptHandler
      * a composer.json and set new options, making them immediately available
      * to forthcoming listeners.
      */
-    protected static $options = [
+    protected static $options = array(
         'symfony-app-dir' => 'app',
         'symfony-web-dir' => 'web',
         'symfony-env' => false,
         'symfony-assets-install' => 'hard',
         'symfony-cache-warmup' => false,
-    ];
+    );
 
     /**
      * Asks if the new directory structure should be used, installs the structure if needed.
@@ -206,7 +206,7 @@ class ScriptHandler
             }
             $fs->copy(__DIR__.'/../Resources/skeleton/app/SymfonyRequirements.php', $varDir.'/SymfonyRequirements.php', true);
             $fs->copy(__DIR__.'/../Resources/skeleton/app/check.php', $binDir.'/symfony_requirements', true);
-            $fs->remove([$appDir.'/check.php', $appDir.'/SymfonyRequirements.php', true]);
+            $fs->remove(array($appDir.'/check.php', $appDir.'/SymfonyRequirements.php', true));
 
             $fs->dumpFile($binDir.'/symfony_requirements', '#!/usr/bin/env php'."\n".str_replace(".'/SymfonyRequirements.php'", ".'/".$fs->makePathRelative($varDir, $binDir)."SymfonyRequirements.php'", file_get_contents($binDir.'/symfony_requirements')));
             $fs->chmod($binDir.'/symfony_requirements', 0755);
@@ -249,7 +249,7 @@ class ScriptHandler
             unlink($file);
         }
 
-        $classes = [
+        $classes = array(
             'Symfony\\Component\\HttpFoundation\\ParameterBag',
             'Symfony\\Component\\HttpFoundation\\HeaderBag',
             'Symfony\\Component\\HttpFoundation\\FileBag',
@@ -267,7 +267,7 @@ class ScriptHandler
             'Symfony\\Component\\Config\\ConfigCache',
             // cannot be included as commands are discovered based on the path to this class via Reflection
             //'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle',
-        ];
+        );
 
         // introspect the autoloader to get the right file
         // we cannot use class_exist() here as it would load the class
@@ -341,16 +341,16 @@ EOF
 
         $fs = new Filesystem();
 
-        $fs->mkdir([$binDir, $varDir]);
+        $fs->mkdir(array($binDir, $varDir));
 
-        foreach ([
+        foreach (array(
             $appDir.'/console' => $binDir.'/console',
             $appDir.'/phpunit.xml.dist' => $rootDir.'/phpunit.xml.dist',
-        ] as $source => $target) {
+        ) as $source => $target) {
             $fs->rename($source, $target, true);
         }
 
-        foreach (['/logs', '/cache'] as $dir) {
+        foreach (array('/logs', '/cache') as $dir) {
             $fs->rename($appDir.$dir, $varDir.$dir);
         }
 
@@ -382,12 +382,12 @@ EOF;
         <server name="KERNEL_DIR" value="$appDir/" />
     </php>
 EOF;
-        $phpunit = str_replace(['<directory>../src', '"bootstrap.php.cache"', $phpunitKernelBefore], ['<directory>src', '"'.$varDir.'/bootstrap.php.cache"', $phpunitKernelAfter], file_get_contents($rootDir.'/phpunit.xml.dist'));
+        $phpunit = str_replace(array('<directory>../src', '"bootstrap.php.cache"', $phpunitKernelBefore), array('<directory>src', '"'.$varDir.'/bootstrap.php.cache"', $phpunitKernelAfter), file_get_contents($rootDir.'/phpunit.xml.dist'));
         $composer = str_replace('"symfony-app-dir": "app",', "\"symfony-app-dir\": \"app\",\n        \"symfony-bin-dir\": \"bin\",\n        \"symfony-var-dir\": \"var\",", file_get_contents($rootDir.'/composer.json'));
 
         $fs->dumpFile($webDir.'/app.php', str_replace($appDir.'/bootstrap.php.cache', $varDir.'/bootstrap.php.cache', file_get_contents($webDir.'/app.php')));
         $fs->dumpFile($webDir.'/app_dev.php', str_replace($appDir.'/bootstrap.php.cache', $varDir.'/bootstrap.php.cache', file_get_contents($webDir.'/app_dev.php')));
-        $fs->dumpFile($binDir.'/console', str_replace([".'/bootstrap.php.cache'", ".'/AppKernel.php'"], [".'/".$fs->makePathRelative($varDir, $binDir)."bootstrap.php.cache'", ".'/".$fs->makePathRelative($appDir, $binDir)."AppKernel.php'"], file_get_contents($binDir.'/console')));
+        $fs->dumpFile($binDir.'/console', str_replace(array(".'/bootstrap.php.cache'", ".'/AppKernel.php'"), array(".'/".$fs->makePathRelative($varDir, $binDir)."bootstrap.php.cache'", ".'/".$fs->makePathRelative($appDir, $binDir)."AppKernel.php'"), file_get_contents($binDir.'/console')));
         $fs->dumpFile($rootDir.'/phpunit.xml.dist', $phpunit);
         $fs->dumpFile($rootDir.'/composer.json', $composer);
 
@@ -421,7 +421,7 @@ EOF;
 
     protected static function getPhpArguments()
     {
-        $arguments = [];
+        $arguments = array();
 
         $phpFinder = new PhpExecutableFinder();
         if (method_exists($phpFinder, 'findArguments')) {

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -27,12 +27,13 @@ class ScriptHandler
      * a composer.json and set new options, making them immediately available
      * to forthcoming listeners.
      */
-    protected static $options = array(
+    protected static $options = [
         'symfony-app-dir' => 'app',
         'symfony-web-dir' => 'web',
+        'symfony-env' => false,
         'symfony-assets-install' => 'hard',
         'symfony-cache-warmup' => false,
-    );
+    ];
 
     /**
      * Asks if the new directory structure should be used, installs the structure if needed.
@@ -205,7 +206,7 @@ class ScriptHandler
             }
             $fs->copy(__DIR__.'/../Resources/skeleton/app/SymfonyRequirements.php', $varDir.'/SymfonyRequirements.php', true);
             $fs->copy(__DIR__.'/../Resources/skeleton/app/check.php', $binDir.'/symfony_requirements', true);
-            $fs->remove(array($appDir.'/check.php', $appDir.'/SymfonyRequirements.php', true));
+            $fs->remove([$appDir.'/check.php', $appDir.'/SymfonyRequirements.php', true]);
 
             $fs->dumpFile($binDir.'/symfony_requirements', '#!/usr/bin/env php'."\n".str_replace(".'/SymfonyRequirements.php'", ".'/".$fs->makePathRelative($varDir, $binDir)."SymfonyRequirements.php'", file_get_contents($binDir.'/symfony_requirements')));
             $fs->chmod($binDir.'/symfony_requirements', 0755);
@@ -248,7 +249,7 @@ class ScriptHandler
             unlink($file);
         }
 
-        $classes = array(
+        $classes = [
             'Symfony\\Component\\HttpFoundation\\ParameterBag',
             'Symfony\\Component\\HttpFoundation\\HeaderBag',
             'Symfony\\Component\\HttpFoundation\\FileBag',
@@ -266,7 +267,7 @@ class ScriptHandler
             'Symfony\\Component\\Config\\ConfigCache',
             // cannot be included as commands are discovered based on the path to this class via Reflection
             //'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle',
-        );
+        ];
 
         // introspect the autoloader to get the right file
         // we cannot use class_exist() here as it would load the class
@@ -301,6 +302,13 @@ EOF
             $console .= ' --ansi';
         }
 
+        $options = static::getOptions($event);
+        if ($options['symfony-env']) {
+            $cmd .= ' --env='.$options['symfony-env'];
+        } else {
+            $cmd .= $event->isDevMode() ? ' --env=dev' : ' --env=prod';
+        }
+
         $process = new Process($php.($phpArgs ? ' '.$phpArgs : '').' '.$console.' '.$cmd, null, null, null, $timeout);
         $process->run(function ($type, $buffer) use ($event) { $event->getIO()->write($buffer, false); });
         if (!$process->isSuccessful()) {
@@ -333,16 +341,16 @@ EOF
 
         $fs = new Filesystem();
 
-        $fs->mkdir(array($binDir, $varDir));
+        $fs->mkdir([$binDir, $varDir]);
 
-        foreach (array(
+        foreach ([
             $appDir.'/console' => $binDir.'/console',
             $appDir.'/phpunit.xml.dist' => $rootDir.'/phpunit.xml.dist',
-        ) as $source => $target) {
+        ] as $source => $target) {
             $fs->rename($source, $target, true);
         }
 
-        foreach (array('/logs', '/cache') as $dir) {
+        foreach (['/logs', '/cache'] as $dir) {
             $fs->rename($appDir.$dir, $varDir.$dir);
         }
 
@@ -374,12 +382,12 @@ EOF;
         <server name="KERNEL_DIR" value="$appDir/" />
     </php>
 EOF;
-        $phpunit = str_replace(array('<directory>../src', '"bootstrap.php.cache"', $phpunitKernelBefore), array('<directory>src', '"'.$varDir.'/bootstrap.php.cache"', $phpunitKernelAfter), file_get_contents($rootDir.'/phpunit.xml.dist'));
+        $phpunit = str_replace(['<directory>../src', '"bootstrap.php.cache"', $phpunitKernelBefore], ['<directory>src', '"'.$varDir.'/bootstrap.php.cache"', $phpunitKernelAfter], file_get_contents($rootDir.'/phpunit.xml.dist'));
         $composer = str_replace('"symfony-app-dir": "app",', "\"symfony-app-dir\": \"app\",\n        \"symfony-bin-dir\": \"bin\",\n        \"symfony-var-dir\": \"var\",", file_get_contents($rootDir.'/composer.json'));
 
         $fs->dumpFile($webDir.'/app.php', str_replace($appDir.'/bootstrap.php.cache', $varDir.'/bootstrap.php.cache', file_get_contents($webDir.'/app.php')));
         $fs->dumpFile($webDir.'/app_dev.php', str_replace($appDir.'/bootstrap.php.cache', $varDir.'/bootstrap.php.cache', file_get_contents($webDir.'/app_dev.php')));
-        $fs->dumpFile($binDir.'/console', str_replace(array(".'/bootstrap.php.cache'", ".'/AppKernel.php'"), array(".'/".$fs->makePathRelative($varDir, $binDir)."bootstrap.php.cache'", ".'/".$fs->makePathRelative($appDir, $binDir)."AppKernel.php'"), file_get_contents($binDir.'/console')));
+        $fs->dumpFile($binDir.'/console', str_replace([".'/bootstrap.php.cache'", ".'/AppKernel.php'"], [".'/".$fs->makePathRelative($varDir, $binDir)."bootstrap.php.cache'", ".'/".$fs->makePathRelative($appDir, $binDir)."AppKernel.php'"], file_get_contents($binDir.'/console')));
         $fs->dumpFile($rootDir.'/phpunit.xml.dist', $phpunit);
         $fs->dumpFile($rootDir.'/composer.json', $composer);
 
@@ -393,6 +401,8 @@ EOF;
         $options = array_merge(static::$options, $event->getComposer()->getPackage()->getExtra());
 
         $options['symfony-assets-install'] = getenv('SYMFONY_ASSETS_INSTALL') ?: $options['symfony-assets-install'];
+
+        $options['symfony-env'] = getenv('SYMFONY_ENV') ?: $options['symfony-env'];
 
         $options['process-timeout'] = $event->getComposer()->getConfig()->get('process-timeout');
 
@@ -411,7 +421,7 @@ EOF;
 
     protected static function getPhpArguments()
     {
-        $arguments = array();
+        $arguments = [];
 
         $phpFinder = new PhpExecutableFinder();
         if (method_exists($phpFinder, 'findArguments')) {

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -30,7 +30,7 @@ class ScriptHandler
     protected static $options = array(
         'symfony-app-dir' => 'app',
         'symfony-web-dir' => 'web',
-        'symfony-env' => false,
+        'symfony-env' => 'dev',
         'symfony-assets-install' => 'hard',
         'symfony-cache-warmup' => false,
     );
@@ -302,9 +302,8 @@ EOF
             $console .= ' --ansi';
         }
 
-        $options = static::getOptions($event);
-        if ($options['symfony-env']) {
-            $cmd .= ' --env='.$options['symfony-env'];
+        if ('dev' !== $env = static::getOptions($event)['symfony-env']) {
+            $cmd .= '--env='.$env;
         }
 
         $process = new Process($php.($phpArgs ? ' '.$phpArgs : '').' '.$console.' '.$cmd, null, null, null, $timeout);
@@ -398,9 +397,8 @@ EOF;
     {
         $options = array_merge(static::$options, $event->getComposer()->getPackage()->getExtra());
 
-        $options['symfony-assets-install'] = getenv('SYMFONY_ASSETS_INSTALL') ?: $options['symfony-assets-install'];
-
         $options['symfony-env'] = getenv('SYMFONY_ENV') ?: $options['symfony-env'];
+        $options['symfony-assets-install'] = getenv('SYMFONY_ASSETS_INSTALL') ?: $options['symfony-assets-install'];
 
         $options['process-timeout'] = $event->getComposer()->getConfig()->get('process-timeout');
 

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -305,8 +305,6 @@ EOF
         $options = static::getOptions($event);
         if ($options['symfony-env']) {
             $cmd .= ' --env='.$options['symfony-env'];
-        } else {
-            $cmd .= $event->isDevMode() ? ' --env=dev' : ' --env=prod';
         }
 
         $process = new Process($php.($phpArgs ? ' '.$phpArgs : '').' '.$console.' '.$cmd, null, null, null, $timeout);

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -434,8 +434,8 @@ EOF;
     /**
      * Returns a relative path to the directory that contains the `console` command.
      *
-     * @param Event  $event      The command event.
-     * @param string $actionName The name of the action
+     * @param Event $event      The command event.
+     * @param string       $actionName The name of the action
      *
      * @return string|null The path to the console directory, null if not found.
      */


### PR DESCRIPTION
When using composer install command with --no-dev flag, ScriptHandler executes commands without specify environment. 

So, if you have a development dependency in require-dev and this development bundle is loaded in AppKernel only for dev and test environment, when you execute install with --no-dev option you will get an error.

For example, I want to move "sensio/generator-bundle" from "require" to "require-dev" in composer.json, because of I don't want to this code generators be able in production servers. 

``` json
"require-dev": {
    "sensio/generator-bundle": "~3.0"
},
```

In AppKernel this bundle is loaded only for dev and test Symfony environments. 

``` php
if (in_array($this->getEnvironment(), ['dev', 'test'])) {
    $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
    $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
    $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
    $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
}
```

If I do this, when I execute composer install --no-dev command I get a ScriptHandler::clearCache error because it makes an "app/console cache:clear --no-warmup" without specify environment, so "dev".

```
> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache
Script Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache handling the post-install-cmd event terminated with an exception

  [RuntimeException]                                                         
  An error occurred when executing the "'cache:clear --no-warmup'" command
```

**Proposal**
I propose a new option for script handler witch provides this feature in different ways:

You can specify env in composer.json extra:

``` json
"extra": {
    "symfony-env": "prod"
},
```

You can do it with an environment variable:

``` bash
SYMFONY_ENV=prod composer install --no-dev
```
