### PR TITLE
Raising required PHP version for Symfony3

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -376,7 +376,7 @@ class RequirementCollection implements IteratorAggregate
  */
 class SymfonyRequirements extends RequirementCollection
 {
-    const REQUIRED_PHP_VERSION = '5.3.3';
+    const REQUIRED_PHP_VERSION = '5.5.9';
 
     /**
      * Constructor that initializes the requirements.


### PR DESCRIPTION
Hi,
as noted in https://github.com/symfony/symfony-standard/pull/946:
not sure why but required PHP version in `SymfonyRequirements.php` is still 5.3.3.
This value is important as is used by e.g. symfony installer for checking system requirements and it's important from DX perspective (See issue symfony/symfony-installer#239)

JZ