### PR TITLE
fixed help message in config template

### DIFF
--- a/Resources/skeleton/web/config.php
+++ b/Resources/skeleton/web/config.php
@@ -96,6 +96,10 @@ $minorProblems = $symfonyRequirements->getFailedRecommendations();
             .sf-reset .ko {
                 background-color: #d66;
             }
+            .sf-reset p.help {
+                padding: 12px 16px;
+                word-break: break-word;
+            }
             .version {
                 text-align: right;
                 font-size: 10px;
@@ -159,7 +163,9 @@ $minorProblems = $symfonyRequirements->getFailedRecommendations();
                             <p>Major problems have been detected and <strong>must</strong> be fixed before continuing:</p>
                             <ol>
                                 <?php foreach ($majorProblems as $problem): ?>
-                                    <li><?php echo $problem->getHelpHtml() ?></li>
+                                    <li><?php echo $problem->getTestMessage() ?>
+                                        <p class="help"><em><?php echo $problem->getHelpHtml() ?></em></p>
+                                    </li>
                                 <?php endforeach; ?>
                             </ol>
                         <?php endif; ?>
@@ -172,7 +178,9 @@ $minorProblems = $symfonyRequirements->getFailedRecommendations();
                             </p>
                             <ol>
                                 <?php foreach ($minorProblems as $problem): ?>
-                                    <li><?php echo $problem->getHelpHtml() ?></li>
+                                    <li><?php echo $problem->getTestMessage() ?>
+                                        <p class="help"><em><?php echo $problem->getHelpHtml() ?></em></p>
+                                    </li>
                                 <?php endforeach; ?>
                             </ol>
                         <?php endif; ?>


### PR DESCRIPTION
I don't know if this the right way to fix this, or if this is the good style to apply, but here's the thing:

 - Before:

 ![help_before](https://cloud.githubusercontent.com/assets/10107633/14362041/103e8ed6-fcfe-11e5-8be0-bc8c899eaf5e.jpg)

 - After:

 ![help_after](https://cloud.githubusercontent.com/assets/10107633/14362069/35471d4c-fcfe-11e5-90e3-bad94d0d7f64.jpg)

To resume the main text seems missing and it may be reason leading to https://github.com/symfony/symfony/issues/18468.

Is this the way to go ? Thanks.