### PR TITLE
Update type hint to use the proper event class

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -15,7 +15,7 @@ use Symfony\Component\ClassLoader\ClassCollectionLoader;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\PhpExecutableFinder;
-use Composer\Script\CommandEvent;
+use Composer\Script\Event;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -37,9 +37,9 @@ class ScriptHandler
     /**
      * Asks if the new directory structure should be used, installs the structure if needed.
      *
-     * @param CommandEvent $event
+     * @param Event $event
      */
-    public static function defineDirectoryStructure(CommandEvent $event)
+    public static function defineDirectoryStructure(Event $event)
     {
         $options = static::getOptions($event);
 
@@ -62,9 +62,9 @@ class ScriptHandler
      * The bootstrap file contains PHP file that are always needed by the application.
      * It speeds up the application bootstrapping.
      *
-     * @param $event CommandEvent A instance
+     * @param Event $event
      */
-    public static function buildBootstrap(CommandEvent $event)
+    public static function buildBootstrap(Event $event)
     {
         $options = static::getOptions($event);
         $bootstrapDir = $autoloadDir = $options['symfony-app-dir'];
@@ -82,7 +82,7 @@ class ScriptHandler
         static::executeBuildBootstrap($event, $bootstrapDir, $autoloadDir, $options['process-timeout']);
     }
 
-    protected static function hasDirectory(CommandEvent $event, $configName, $path, $actionName)
+    protected static function hasDirectory(Event $event, $configName, $path, $actionName)
     {
         if (!is_dir($path)) {
             $event->getIO()->write(sprintf('The %s (%s) specified in composer.json was not found in %s, can not %s.', $configName, $path, getcwd(), $actionName));
@@ -97,14 +97,14 @@ class ScriptHandler
      * Sets up deployment target specific features.
      * Could be custom web server configs, boot command files etc.
      *
-     * @param $event CommandEvent An instance
+     * @param Event $event
      */
-    public static function prepareDeploymentTarget(CommandEvent $event)
+    public static function prepareDeploymentTarget(Event $event)
     {
         static::prepareDeploymentTargetHeroku($event);
     }
 
-    protected static function prepareDeploymentTargetHeroku(CommandEvent $event)
+    protected static function prepareDeploymentTargetHeroku(Event $event)
     {
         $options = static::getOptions($event);
         if (($stack = getenv('STACK')) && ($stack == 'cedar' || $stack == 'cedar-14')) {
@@ -119,9 +119,9 @@ class ScriptHandler
     /**
      * Clears the Symfony cache.
      *
-     * @param $event CommandEvent A instance
+     * @param Event $event
      */
-    public static function clearCache(CommandEvent $event)
+    public static function clearCache(Event $event)
     {
         $options = static::getOptions($event);
         $consoleDir = static::getConsoleDir($event, 'clear the cache');
@@ -148,9 +148,9 @@ class ScriptHandler
      * strict user permission checks (which can be done on Windows 7 but not on Windows
      * Vista).
      *
-     * @param $event CommandEvent A instance
+     * @param Event $event
      */
-    public static function installAssets(CommandEvent $event)
+    public static function installAssets(Event $event)
     {
         $options = static::getOptions($event);
         $consoleDir = static::getConsoleDir($event, 'install assets');
@@ -178,9 +178,9 @@ class ScriptHandler
     /**
      * Updated the requirements file.
      *
-     * @param $event CommandEvent A instance
+     * @param Event $event
      */
-    public static function installRequirementsFile(CommandEvent $event)
+    public static function installRequirementsFile(Event $event)
     {
         $options = static::getOptions($event);
         $appDir = $options['symfony-app-dir'];
@@ -224,7 +224,7 @@ class ScriptHandler
         }
     }
 
-    public static function removeSymfonyStandardFiles(CommandEvent $event)
+    public static function removeSymfonyStandardFiles(Event $event)
     {
         $options = static::getOptions($event);
         $appDir = $options['symfony-app-dir'];
@@ -241,7 +241,7 @@ class ScriptHandler
         $fs->remove($appDir.'/SymfonyStandard');
     }
 
-    public static function installAcmeDemoBundle(CommandEvent $event)
+    public static function installAcmeDemoBundle(Event $event)
     {
         $rootDir = getcwd();
         $options = static::getOptions($event);
@@ -424,7 +424,7 @@ EOF
             , $autoloadDir, $bootstrapContent));
     }
 
-    protected static function executeCommand(CommandEvent $event, $consoleDir, $cmd, $timeout = 300)
+    protected static function executeCommand(Event $event, $consoleDir, $cmd, $timeout = 300)
     {
         $php = escapeshellarg(static::getPhp(false));
         $phpArgs = implode(' ', array_map('escapeshellarg', static::getPhpArguments()));
@@ -440,7 +440,7 @@ EOF
         }
     }
 
-    protected static function executeBuildBootstrap(CommandEvent $event, $bootstrapDir, $autoloadDir, $timeout = 300)
+    protected static function executeBuildBootstrap(Event $event, $bootstrapDir, $autoloadDir, $timeout = 300)
     {
         $php = escapeshellarg(static::getPhp(false));
         $phpArgs = implode(' ', array_map('escapeshellarg', static::getPhpArguments()));
@@ -459,7 +459,7 @@ EOF
         }
     }
 
-    protected static function updateDirectoryStructure(CommandEvent $event, $rootDir, $appDir, $binDir, $varDir, $webDir)
+    protected static function updateDirectoryStructure(Event $event, $rootDir, $appDir, $binDir, $varDir, $webDir)
     {
         $event->getIO()->write('Updating Symfony directory structure...');
 
@@ -520,7 +520,7 @@ EOF;
         $fs->chmod($binDir.'/console', 0755);
     }
 
-    protected static function getOptions(CommandEvent $event)
+    protected static function getOptions(Event $event)
     {
         $options = array_merge(static::$options, $event->getComposer()->getPackage()->getExtra());
 
@@ -560,12 +560,12 @@ EOF;
     /**
      * Returns a relative path to the directory that contains the `console` command.
      *
-     * @param CommandEvent $event      The command event.
+     * @param Event $event      The command event.
      * @param string       $actionName The name of the action
      *
      * @return string|null The path to the console directory, null if not found.
      */
-    protected static function getConsoleDir(CommandEvent $event, $actionName)
+    protected static function getConsoleDir(Event $event, $actionName)
     {
         $options = static::getOptions($event);
 


### PR DESCRIPTION
Without this fix, people upgrading to composer 1.1 when it's out (or snapshots right now) will get a lot of:

> Deprecation Notice: The callback Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::installRequirementsFile declared at vendor\sensio\distribution-bundle\Sensio\Bundle\DistributionBundle\Composer\ScriptHandler.php accepts a Composer\Script\CommandEvent but symfony events use a Composer\Script\Event instance. Please adjust your type hint accordingly, see https://getcomposer.org/doc/articles/scripts.md#event-classes

It's compatible with pretty old composer versions at this point so the change is harmless IMO.