### PR TITLE
catch RouteNotFoundException instead of \Exception

### DIFF
--- a/Controller/ConfiguratorController.php
+++ b/Controller/ConfiguratorController.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Sensio\Bundle\DistributionBundle\Configurator\Step\StepInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * ConfiguratorController.
@@ -92,7 +93,7 @@ class ConfiguratorController extends ContainerAware
 
         try {
             $welcomeUrl = $this->container->get('router')->generate('_welcome');
-        } catch (\Exception $e) {
+        } catch (RouteNotFoundException $e) {
             $welcomeUrl = null;
         }
 


### PR DESCRIPTION
I was looking for "catch all" statements and found this. IMHO the intention is not to ignore every possible error, including those in userland-implemented-routers (which could hide bugs), but to ignore the route, if it's not registered.

Btw, where did this class disappear in master? 