### PR TITLE
Fix check.php Error when .ini file not found

### DIFF
--- a/Resources/skeleton/app/check.php
+++ b/Resources/skeleton/app/check.php
@@ -12,7 +12,7 @@ echo '> PHP is using the following php.ini file:'.PHP_EOL;
 if ($iniPath) {
     echo_style('green', '  '.$iniPath);
 } else {
-    echo_style('warning', '  WARNING: No configuration file (php.ini) used by PHP!');
+    echo_style('yellow', '  WARNING: No configuration file (php.ini) used by PHP!');
 }
 
 echo PHP_EOL.PHP_EOL;


### PR DESCRIPTION
Small typo leading to this error:

```
Symfony Requirements Checker

PHP is using the following php.ini file:
PHP Notice:  Undefined index: warning in /var/www/bin/symfony_requirements on line 114
PHP Stack trace:
PHP   1. {main}() /var/www/bin/symfony_requirements:0
PHP   2. echo_style() /var/www/bin/symfony_requirements:16

Notice: Undefined index: warning in /var/www/bin/symfony_requirements on line 114

Call Stack:
    0.0003     322936   1. {main}() /var/www/bin/symfony_requirements:0
    0.0152    1208360   2. echo_style() /var/www/bin/symfony_requirements:16
```

With the fix we have this:

![screenshot from 2016-06-23 17 06 06](https://cloud.githubusercontent.com/assets/2279794/16308340/e937703e-3964-11e6-88e4-f2e382c8acb3.png)


Keep up the good work !