### PR TITLE
Fixed requirements link from config.php

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -216,11 +216,9 @@ class ScriptHandler
         // if the user has already removed the config.php file, do nothing
         // as the file must be removed for production use
         if ($fs->exists($webDir.'/config.php')) {
-            if (!$newDirectoryStructure) {
-                $fs->copy(__DIR__.'/../Resources/skeleton/web/config.php', $webDir.'/config.php', true);
-            } else {
-                $fs->dumpFile($webDir.'/config.php', str_replace('/../app/SymfonyRequirements.php', '/'.$fs->makePathRelative($varDir, $webDir).'SymfonyRequirements.php', file_get_contents(__DIR__.'/../Resources/skeleton/web/config.php')));
-            }
+            $requiredDir = $newDirectoryStructure ? $varDir : $appDir;
+
+            $fs->dumpFile($webDir.'/config.php', str_replace('/../app/SymfonyRequirements.php', '/'.$fs->makePathRelative($requiredDir, $webDir).'SymfonyRequirements.php', file_get_contents(__DIR__.'/../Resources/skeleton/web/config.php')));
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/sensiolabs/SensioDistributionBundle/issues/234.

In 2.7 or 2.8 using the old directory structure, the extra option "symfony-app-dir" in `composer.json` is already available and the `web/config.php`  should include the path accordingly as done [here](https://github.com/sensiolabs/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php#L195).