### PR TITLE
Dont inline Kernel when already there

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -253,7 +253,6 @@ class ScriptHandler
             'Symfony\\Component\\HttpFoundation\\ServerBag',
             'Symfony\\Component\\HttpFoundation\\Request',
 
-            'Symfony\\Component\\HttpKernel\\Kernel',
             'Symfony\\Component\\ClassLoader\\ClassCollectionLoader',
             'Symfony\\Component\\ClassLoader\\ApcClassLoader',
         );


### PR DESCRIPTION
As spotted in https://github.com/symfony/symfony/issues/20753#issuecomment-264819158
`Kernel` inlining is not compatible with old `"files": ["app/AppKernel.php"]` entries in composer.json