### PR TITLE
Adds the environment parameter to ::executeCommand

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -273,7 +273,7 @@ EOF
             , $bootstrapContent));
     }
 
-    protected static function executeCommand(Event $event, $consoleDir, $cmd, $timeout = 300)
+    protected static function executeCommand(Event $event, $consoleDir, $cmd, $env = null, $timeout = 300)
     {
         $php = escapeshellarg(static::getPhp(false));
         $phpArgs = implode(' ', array_map('escapeshellarg', static::getPhpArguments()));
@@ -282,7 +282,7 @@ EOF
             $console .= ' --ansi';
         }
 
-        $process = new Process($php.($phpArgs ? ' '.$phpArgs : '').' '.$console.' '.$cmd, null, null, null, $timeout);
+        $process = new Process($php.($phpArgs ? ' '.$phpArgs : '').' '.$console.' '.$cmd, null, $env, null, $timeout);
         $process->run(function ($type, $buffer) use ($event) { $event->getIO()->write($buffer, false); });
         if (!$process->isSuccessful()) {
             throw new \RuntimeException(sprintf("An error occurred when executing the \"%s\" command:\n\n%s\n\n%s.", escapeshellarg($cmd), $process->getOutput(), $process->getErrorOutput()));

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -273,7 +273,7 @@ EOF
             , $bootstrapContent));
     }
 
-    protected static function executeCommand(Event $event, $consoleDir, $cmd, $env = null, $timeout = 300)
+    protected static function executeCommand(Event $event, $consoleDir, $cmd, $timeout = 300, $env = null)
     {
         $php = escapeshellarg(static::getPhp(false));
         $phpArgs = implode(' ', array_map('escapeshellarg', static::getPhpArguments()));

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -283,7 +283,9 @@ EOF
         }
 
         $process = new Process($php.($phpArgs ? ' '.$phpArgs : '').' '.$console.' '.$cmd, null, $env, null, $timeout);
-        $process->run(function ($type, $buffer) use ($event) { $event->getIO()->write($buffer, false); });
+        $process->run(function ($type, $buffer) use ($event) {
+            $event->getIO()->write($buffer, false);
+        });
         if (!$process->isSuccessful()) {
             throw new \RuntimeException(sprintf("An error occurred when executing the \"%s\" command:\n\n%s\n\n%s.", escapeshellarg($cmd), $process->getOutput(), $process->getErrorOutput()));
         }
@@ -302,7 +304,9 @@ EOF
         }
 
         $process = new Process($php.($phpArgs ? ' '.$phpArgs : '').' '.$cmd.' '.$bootstrapDir.' '.$autoloadDir.' '.$useNewDirectoryStructure, getcwd(), null, null, $timeout);
-        $process->run(function ($type, $buffer) use ($event) { $event->getIO()->write($buffer, false); });
+        $process->run(function ($type, $buffer) use ($event) {
+            $event->getIO()->write($buffer, false);
+        });
         if (!$process->isSuccessful()) {
             throw new \RuntimeException('An error occurred when generating the bootstrap file.');
         }
@@ -421,7 +425,7 @@ EOF;
      * @param Event  $event      The command event
      * @param string $actionName The name of the action
      *
-     * @return string|null The path to the console directory, null if not found.
+     * @return string|null the path to the console directory, null if not found
      */
     protected static function getConsoleDir(Event $event, $actionName)
     {


### PR DESCRIPTION
This PR adds an optional `$env` parameter to the command run. Lots of systems nowadays use an environment variables to manipulate their system behaviour. During post composer's install you might like to run (e.g.) assets install not just for a particular env var, but multiple. What requires forking a process with a specific env. Hereby this PR is here.