### PR TITLE
New Heroku stack and simpler Procfile

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -107,7 +107,7 @@ class ScriptHandler
     protected static function prepareDeploymentTargetHeroku(Event $event)
     {
         $options = static::getOptions($event);
-        if (($stack = getenv('STACK')) && ($stack == 'cedar' || $stack == 'cedar-14')) {
+        if (($stack = getenv('STACK')) && ($stack == 'cedar-14' || $stack == 'heroku-16')) {
             $fs = new Filesystem();
             if (!$fs->exists('Procfile')) {
                 $event->getIO()->write('Heroku deploy detected; creating default Procfile for "web" dyno');

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -111,7 +111,7 @@ class ScriptHandler
             $fs = new Filesystem();
             if (!$fs->exists('Procfile')) {
                 $event->getIO()->write('Heroku deploy detected; creating default Procfile for "web" dyno');
-                $fs->dumpFile('Procfile', sprintf('web: $(composer config bin-dir)/heroku-php-apache2 %s/', $options['symfony-web-dir']));
+                $fs->dumpFile('Procfile', sprintf('web: heroku-php-apache2 %s/', $options['symfony-web-dir']));
             }
         }
     }


### PR DESCRIPTION
The `cedar` stack has been retired in late 2015 (https://devcenter.heroku.com/changelog-items/755), but `heroku-16` is in beta now.

The `heroku-php-apache2` and friends boot scripts are also always on `$PATH`, so the command can be simplified.