### PR TITLE
Allow building bootstrap.php.cache when app/autoload.php is absent

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -75,6 +75,11 @@ class ScriptHandler
                 return;
             }
         }
+
+        if (!static::useSymfonyAutoloader($options)) {
+            $autoloadDir = $options['vendor-dir'];
+        }
+
         if (!static::hasDirectory($event, 'symfony-app-dir', $autoloadDir, 'build bootstrap file')) {
             return;
         }
@@ -377,6 +382,7 @@ EOF;
         $options['symfony-cache-warmup'] = getenv('SYMFONY_CACHE_WARMUP') ?: $options['symfony-cache-warmup'];
 
         $options['process-timeout'] = $event->getComposer()->getConfig()->get('process-timeout');
+        $options['vendor-dir'] = $event->getComposer()->getConfig()->get('vendor-dir');
 
         return $options;
     }
@@ -452,5 +458,17 @@ EOF;
     protected static function useNewDirectoryStructure(array $options)
     {
         return isset($options['symfony-var-dir']) && is_dir($options['symfony-var-dir']);
+    }
+
+    /**
+     * Returns true if the application bespoke autoloader is used.
+     *
+     * @param array $options Composer options
+     *
+     * @return bool
+     */
+    protected static function useSymfonyAutoloader(array $options)
+    {
+        return isset($options['symfony-app-dir']) && is_file($options['symfony-app-dir'].'/autoload.php');
     }
 }


### PR DESCRIPTION
If app/autoload.php is absent then use the autoload.php in Composer's
vendor directory.

symfony/symfony#21837 opens the door for removing `app/autoload.php` in Symfony apps. I tried removing that and updating the various reference to it in symfony-standard and my app works (:tada:), but when I run composer install/update it complains about the buildBootstrap task expecting to find `app/autoload.php`.

This fix tells the buildBootstrap task to use `vendor/autoload.php` if `app/autoload.php` is absent.