### PR TITLE
Remove decoration from forwarded exception

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -290,7 +290,7 @@ EOF
         $process = new Process($php.($phpArgs ? ' '.$phpArgs : '').' '.$console.' '.$cmd, null, null, null, $timeout);
         $process->run(function ($type, $buffer) use ($event) { $event->getIO()->write($buffer, false); });
         if (!$process->isSuccessful()) {
-            throw new \RuntimeException(sprintf("An error occurred when executing the \"%s\" command:\n\n%s\n\n%s.", escapeshellarg($cmd), $process->getOutput(), $process->getErrorOutput()));
+            throw new \RuntimeException(sprintf("An error occurred when executing the \"%s\" command:\n\n%s\n\n%s", escapeshellarg($cmd), self::removeDecoration($process->getOutput()), self::removeDecoration($process->getErrorOutput())));
         }
     }
 
@@ -470,5 +470,10 @@ EOF;
     protected static function useSymfonyAutoloader(array $options)
     {
         return isset($options['symfony-app-dir']) && is_file($options['symfony-app-dir'].'/autoload.php');
+    }
+
+    private static function removeDecoration($string)
+    {
+        return preg_replace("/\033\[[^m]*m/", '', $string);
     }
 }


### PR DESCRIPTION
See https://github.com/symfony/symfony/issues/22618

before
![image](https://cloud.githubusercontent.com/assets/1047696/25667089/bed3c6a2-3022-11e7-9557-baa9e8a5a71c.png)


after
![image](https://cloud.githubusercontent.com/assets/1047696/25667328/7935c46e-3023-11e7-8562-ab2a077dd487.png)

