### PR TITLE
Added a warmup function for the cache of symfony

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -144,6 +144,22 @@ class ScriptHandler
     }
 
     /**
+     * Warm up the Symfony cache.
+     *
+     * @param Event $event
+     */
+    public static function warmupCache(Event $event)
+    {
+        $options = static::getOptions($event);
+        $consoleDir = static::getConsoleDir($event, 'Warm up the cache');
+        if (null === $consoleDir) {
+            return;
+        }
+
+        static::executeCommand($event, $consoleDir, 'cache:warmup', $options['process-timeout']);
+    }
+
+    /**
      * Installs the assets under the web root directory.
      *
      * For better interoperability, assets are copied instead of symlinked by default.

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -198,7 +198,7 @@ class ScriptHandler
     }
 
     /**
-     * Updates the requirements file.
+     * Updated the requirements file.
      *
      * @param Event $event
      */

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -144,14 +144,15 @@ class ScriptHandler
     }
 
     /**
-     * Warm up the Symfony cache.
+     * Warms up the Symfony cache.
      *
      * @param Event $event
      */
     public static function warmupCache(Event $event)
     {
         $options = static::getOptions($event);
-        $consoleDir = static::getConsoleDir($event, 'Warm up the cache');
+        $consoleDir = static::getConsoleDir($event, 'warm up the cache');
+
         if (null === $consoleDir) {
             return;
         }
@@ -197,7 +198,7 @@ class ScriptHandler
     }
 
     /**
-     * Updated the requirements file.
+     * Updates the requirements file.
      *
      * @param Event $event
      */


### PR DESCRIPTION
According to what is mentioned [here](http://symfony.com/blog/new-in-symfony-3-3-deprecated-cache-clear-with-warmup) clearing the cache with warmup option is deprecated.

So if some one wants to add a warmup in composer he will either have to set the composer option of warmup to true which will add the warmup to clearCache or add [here](https://github.com/symfony/symfony-standard/blob/3.3/composer.json#L37) the command

`php bin/console cache:warmup` 

For consistency reasons and since there is already a function for clearing the cache I submit this PR in order instead of having the command above to have:

`Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::warmupCache`