### PR TITLE
Replace create_function() calls by closures

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -555,7 +555,7 @@ class SymfonyRequirements extends RequirementCollection
         if (extension_loaded('mbstring')) {
             $this->addPhpIniRequirement(
                 'mbstring.func_overload',
-                function ($cfgValue) { return (int) $cfgValue === 0; },
+                function ($cfgValue) { return 0 === (int) $cfgValue; },
                 true,
                 'string functions should not be overloaded',
                 'Set "<strong>mbstring.func_overload</strong>" to <strong>0</strong> in php.ini<a href="#phpini">*</a> to disable function overloading by the mbstring extension.'
@@ -704,7 +704,7 @@ class SymfonyRequirements extends RequirementCollection
 
             $this->addPhpIniRecommendation(
                 'intl.error_level',
-                function ($cfgValue) { return (int) $cfgValue === 0; },
+                function ($cfgValue) { return 0 === (int) $cfgValue; },
                 true,
                 'intl.error_level should be 0 in php.ini',
                 'Set "<strong>intl.error_level</strong>" to "<strong>0</strong>" in php.ini<a href="#phpini">*</a> to inhibit the messages when an error occurs in ICU functions.'


### PR DESCRIPTION
Fix php 7.2.0 deprecation
See http://php.net/manual/en/function.create-function.php
See https://github.com/symfony/requirements-checker/pull/11