### PR TITLE
Fix: Timezone Requirement

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -446,15 +446,8 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         if (false !== $requiredPhpVersion && version_compare($installedPhpVersion, $requiredPhpVersion, '>=')) {
-            $timezones = array();
-            foreach (DateTimeZone::listAbbreviations() as $abbreviations) {
-                foreach ($abbreviations as $abbreviation) {
-                    $timezones[$abbreviation['timezone_id']] = true;
-                }
-            }
-
             $this->addRequirement(
-                isset($timezones[@date_default_timezone_get()]),
+                in_array(@date_default_timezone_get(), \DateTimeZone::listIdentifiers(), true),
                 sprintf('Configured default timezone "%s" must be supported by your installation of PHP', @date_default_timezone_get()),
                 'Your default timezone is not supported by PHP. Check for typos in your <strong>php.ini</strong> file and have a look at the list of deprecated timezones at <a href="http://php.net/manual/en/timezones.others.php">http://php.net/manual/en/timezones.others.php</a>.'
             );


### PR DESCRIPTION
Based on the issue of the timelib library, symfony can't use listAbbreviations method to check timezone, the recomendation is to use listIdentifiers method instead.

Related issues:

[https://github.com/derickr/timelib/issues/34](https://github.com/derickr/timelib/issues/34)
[https://github.com/sensiolabs/SensioDistributionBundle/issues/337](https://github.com/sensiolabs/SensioDistributionBundle/issues/337)
[https://github.com/symfony/symfony/issues/26550](https://github.com/symfony/symfony/issues/26550)