### PR TITLE
Allow wider range of security checker on version 4.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/framework-bundle": "~2.3",
         "symfony/class-loader": "~2.2",
         "symfony/process": "~2.2",
-        "sensiolabs/security-checker": "~3.0"
+        "sensiolabs/security-checker": "~3.0|~4.0|~5.0"
     },
     "require-dev": {
         "symfony/form": "~2.2",


### PR DESCRIPTION
I'm not 100% sure if the 4.0 branch is still maintained, but this would ease the upgrading path to the new security checker.

This still allows the older versions to make sure there is no BC break if the system is incompatible with the new versions

Related to https://github.com/sensiolabs/security-checker/issues/133#issuecomment-444121362